### PR TITLE
Avoid calling `buildFinished` after build is finished

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -1,5 +1,6 @@
 package com.gradle;
 
+import com.gradle.scan.plugin.BuildResult;
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
@@ -7,6 +8,8 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.testing.Test;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
@@ -29,12 +32,15 @@ final class CustomBuildScanEnhancements {
 
     private final BuildScanExtension buildScan;
     private final ProviderFactory providers;
+    private final CustomValueSearchLinker customValueSearchLinker;
     private final Gradle gradle;
 
     CustomBuildScanEnhancements(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
         this.buildScan = buildScan;
         this.providers = providers;
         this.gradle = gradle;
+        this.customValueSearchLinker = new CustomValueSearchLinker(buildScan);
+        buildScan.buildFinished(customValueSearchLinker);
     }
 
     // Apply all build scan enhancements via custom tags, links, and values
@@ -264,15 +270,17 @@ final class CustomBuildScanEnhancements {
     }
 
     private void captureGitMetadata() {
-        buildScan.background(new CaptureGitMetadataAction(providers));
+        buildScan.background(new CaptureGitMetadataAction(providers, customValueSearchLinker));
     }
 
     private static final class CaptureGitMetadataAction implements Action<BuildScanExtension> {
 
         private final ProviderFactory providers;
+        private final CustomValueSearchLinker customValueSearchLinker;
 
-        private CaptureGitMetadataAction(ProviderFactory providers) {
+        private CaptureGitMetadataAction(ProviderFactory providers, CustomValueSearchLinker customValueSearchLinker) {
             this.providers = providers;
+            this.customValueSearchLinker = customValueSearchLinker;
         }
 
         @Override
@@ -294,7 +302,7 @@ final class CustomBuildScanEnhancements {
                 buildScan.value("Git commit id", gitCommitId);
             }
             if (isNotEmpty(gitCommitShortId)) {
-                addCustomValueAndSearchLink(buildScan, "Git commit id", "Git commit id short", gitCommitShortId);
+                addCustomValueAndSearchLink(buildScan, customValueSearchLinker, "Git commit id", "Git commit id short", gitCommitShortId);
             }
             if (isNotEmpty(gitBranchName)) {
                 buildScan.tag(gitBranchName);
@@ -349,22 +357,43 @@ final class CustomBuildScanEnhancements {
     }
 
     private void addCustomValueAndSearchLink(String name, String value) {
-        addCustomValueAndSearchLink(buildScan, name, name, value);
+        addCustomValueAndSearchLink(buildScan, customValueSearchLinker, name, name, value);
     }
 
-    private static void addCustomValueAndSearchLink(BuildScanExtension buildScan, String linkLabel, String name, String value) {
-        // Set custom values immediately, but do not add custom links until 'buildFinished' since
-        // creating customs links requires the server url to be fully configured
+    private static void addCustomValueAndSearchLink(BuildScanExtension buildScan, CustomValueSearchLinker customValueSearchLinker, String linkLabel, String name, String value) {
         buildScan.value(name, value);
-        buildScan.buildFinished(result -> addSearchLinkForCustomValue(buildScan, linkLabel, name, value));
+        customValueSearchLinker.registerLink(linkLabel, name, value);
     }
 
-    private static void addSearchLinkForCustomValue(BuildScanExtension buildScan, String linkLabel, String name, String value) {
-        String server = buildScan.getServer();
-        if (server != null) {
+    /**
+     * Collects custom values that should have a search link, and creates these links in `buildFinished`.
+     * The actual construction of the links must be deferred to ensure the Server URL is set.
+     * This functionality needs to be in a separate static class in order to work with configuration cache.
+     */
+    private static class CustomValueSearchLinker implements Action<BuildResult> {
+        private final Map<String, String> customValueLinks = new LinkedHashMap<>();
+        private final BuildScanExtension buildScan;
+
+        private CustomValueSearchLinker(BuildScanExtension buildScan) {
+            this.buildScan = buildScan;
+        }
+
+        public synchronized void registerLink(String linkLabel, String name, String value) {
             String searchParams = "search.names=" + urlEncode(name) + "&search.values=" + urlEncode(value);
-            String url = appendIfMissing(server, "/") + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}");
-            buildScan.link(linkLabel + " build scans", url);
+            customValueLinks.put(linkLabel, searchParams);
+        }
+
+        @Override
+        public synchronized void execute(BuildResult buildResult) {
+            String server = buildScan.getServer();
+            if (server == null) {
+                return;
+            }
+
+            customValueLinks.forEach((linkLabel, searchParams) -> {
+                String url = appendIfMissing(server, "/") + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}");
+                buildScan.link(linkLabel + " build scans", url);
+            });
         }
     }
 


### PR DESCRIPTION
Search links for custom values must be added during a 'buildFinished' event,
in order to ensure that the server URL is set to it's final value.
The previous implementation did this by registering a separate 'buildFinished'
listener for each search link, but the background process that captured git metadata
would occasionally register after the build was complete.

In order to avoid the warnings issued in this case, we now register a single
buildFinished listener, with a thread-safe implementation that will collect all
registered build scans. With this change, if the git metadata process completes after
the build is complete, then the search link is ignored and no warning is issued.

Note that configuration-cache compliance necessitated the use of a static class
to register as a buildFinished listener.

Fixes #4