### PR TITLE
Fix missing signature files when publishing to the plugin portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ java {
 }
 
 gradlePlugin {
+    automatedPublishing = false
+
     plugins {
         commonCustomUserData {
             id = 'com.gradle.common-custom-user-data-gradle-plugin'
@@ -49,6 +51,11 @@ pluginBundle {
     website = 'https://github.com/gradle/common-custom-user-data-gradle-plugin'
     vcsUrl = 'https://github.com/gradle/common-custom-user-data-gradle-plugin.git'
     tags = ['android', 'java', 'gradle enterprise']
+
+    mavenCoordinates {
+        groupId = 'com.gradle'
+        artifactId = 'common-custom-user-data-gradle-plugin'
+    }
 }
 
 signing {


### PR DESCRIPTION
`plugin-publish` Gradle plugin starting from version 0.14.0 does not publish the signature files when used with the `maven-publish` Gradle plugin.

Until this bug is fixed, this PR:
- keeps the `maven-publish` plugin so users can still build and publish to their internal repository
- configures the `plugin-publish` so it ignores the `maven-publish` model and publish the signatures