### PR TITLE
Fix error with Gradle project isolation enabled

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [FIX] - Fix plugin failure with Gradle project isolation enabled

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -400,7 +400,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private void captureTestParallelization() {
-        gradle.allprojects(p ->
+        gradle.afterProject(p ->
             p.getTasks().withType(Test.class).configureEach(captureMaxParallelForks(buildScan))
         );
     }


### PR DESCRIPTION
Replaces `gradle.allprojects` call with `gradle.afterProject` since the former is not compatible with Gradle project isolation.

Fixes #24