### PR TITLE
Enable remote build caching

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+      GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_SOLUTIONS_CACHE_USERNAME }}
+      GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,4 +15,21 @@ gradleEnterprise {
     }
 }
 
+buildCache {
+    local {
+        enabled = true
+    }
+
+    remote(HttpBuildCache) {
+        url = 'https://ge.solutions-team.gradle.com/cache/'
+        allowUntrustedServer = false
+        credentials { creds ->
+            creds.username = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
+            creds.password = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
+        }
+        enabled = true
+        push = isCI
+    }
+}
+
 rootProject.name = 'common-custom-user-data-gradle-plugin'


### PR DESCRIPTION
This change enables the remote build cache for all builds. Anonymous
users have read-only build cache access, while CI has read-write.

This change also configures GitHub actions to authenticate with the
build cache.