### PR TITLE
Add "Set up Gradle" step to GHActions workflows

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Build with Gradle
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build -x signArchives -i
+      - name: Build with Gradle
+        run: ./gradlew build -x signArchives -i

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Upgrade Wrappers
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: 'clean upgradeGradleWrapperAll --continue'
+      - name: Upgrade Wrappers
+        run: ./gradlew clean upgradeGradleWrapperAll --continue
         env:
           WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Separating the setup of the Gradle build tool from actual build invocation
is more idiomatic to GH Actions in general, and provides a clearer separation
of responsibilities.