### PR TITLE
Proxy Gradle Enterprise plugin types to work around ClassLoader issues

### DIFF
--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -39,7 +39,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
             CustomGradleEnterpriseConfig customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig();
 
-            GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
+            Object extension = settings.getExtensions().getByName("gradleEnterprise");
+            GradleEnterpriseExtension gradleEnterprise = ProxyFactory.createProxy(extension, GradleEnterpriseExtension.class);
             customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
@@ -67,7 +68,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         project.getPluginManager().withPlugin("com.gradle.build-scan", __ -> {
             CustomGradleEnterpriseConfig customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig();
 
-            GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
+            Object extension = project.getExtensions().getByName("gradleEnterprise");
+            GradleEnterpriseExtension gradleEnterprise = ProxyFactory.createProxy(extension, GradleEnterpriseExtension.class);
             customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();

--- a/src/main/java/com/gradle/ProxyFactory.java
+++ b/src/main/java/com/gradle/ProxyFactory.java
@@ -1,0 +1,108 @@
+package com.gradle;
+
+import org.gradle.api.Action;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.*;
+
+class ProxyFactory {
+
+    static <T> T createProxy(Object target, Class<T> targetInterface) {
+        return newProxyInstance(targetInterface, new ProxyingInvocationHandler(target));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T newProxyInstance(Class<T> targetInterface, InvocationHandler invocationHandler) {
+        return (T) Proxy.newProxyInstance(targetInterface.getClassLoader(), new Class[]{targetInterface}, invocationHandler);
+    }
+
+    private static class ProxyingInvocationHandler implements InvocationHandler {
+
+        private final Object target;
+
+        ProxyingInvocationHandler(Object target) {
+            this.target = target;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            try {
+                Class<?>[] parameterTypes = method.getParameterTypes();
+                Method targetMethod = target.getClass().getMethod(method.getName(), convertTypes(parameterTypes, target.getClass().getClassLoader()));
+                Object result = targetMethod.invoke(target, toTargetArgs(args));
+                if (result == null || isJdkType(result.getClass())) {
+                    return result;
+                }
+                return createProxy(result, method.getReturnType());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to invoke " + method + " on " + target + " with args " + Arrays.toString(args), e);
+            }
+        }
+
+        private Object[] toTargetArgs(Object[] args) {
+            if (args == null || args.length == 0) {
+                return args;
+            }
+            if (args.length == 1 && args[0] instanceof Action) {
+                return new Object[]{adaptActionArg((Action<?>) args[0])};
+            }
+            if (Arrays.stream(args).allMatch(it -> isJdkType(it.getClass()))) {
+                return args;
+            }
+            throw new RuntimeException("Unsupported argument types in " + Arrays.toString(args));
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private Action<Object> adaptActionArg(Action action) {
+            return arg -> action.execute(createLocalProxy(arg));
+        }
+
+        private Object createLocalProxy(Object target) {
+            ClassLoader localClassLoader = ProxyFactory.class.getClassLoader();
+            return Proxy.newProxyInstance(
+                    localClassLoader,
+                    convertTypes(collectInterfaces(target.getClass()), localClassLoader),
+                    new ProxyingInvocationHandler(target)
+            );
+        }
+
+        public static Class<?>[] collectInterfaces(final Class<?> type) {
+            Set<Class<?>> result = new LinkedHashSet<>();
+            collectInterfaces(type, result);
+            return result.toArray(new Class<?>[0]);
+        }
+
+        private static void collectInterfaces(Class<?> type, Set<Class<?>> result) {
+            for (Class<?> candidate = type; candidate != null; candidate = candidate.getSuperclass()) {
+                for (Class<?> i : candidate.getInterfaces()) {
+                    if (result.add(i)) {
+                        collectInterfaces(i, result);
+                    }
+                }
+            }
+        }
+
+        private static Class<?>[] convertTypes(Class<?>[] parameterTypes, ClassLoader classLoader) {
+            if (parameterTypes.length == 0) {
+                return parameterTypes;
+            }
+            return Arrays.stream(parameterTypes)
+                    .map(type -> {
+                        try {
+                            return classLoader.loadClass(type.getName());
+                        } catch (Exception e) {
+                            throw new RuntimeException("Failed to load class: " + type.getName(), e);
+                        }
+                    })
+                    .toArray(Class<?>[]::new);
+        }
+
+        private boolean isJdkType(Class<?> type) {
+            ClassLoader typeClassLoader = type.getClassLoader();
+            return typeClassLoader == null || typeClassLoader.equals(Object.class.getClassLoader());
+        }
+    }
+
+}


### PR DESCRIPTION
When the GE plugin is applied by the build and the CCUD plugin via an
init script, the Gradle Enterprise extension and types it references
are loaded by a different classloader than the classes in the CCUD
plugin. To work around this issue, the Gradle Enterprise types are now
accessed via dynamic proxies that "translate" between the different
class loaders at runtime.
