### PR TITLE
Add fix for branch name in GitLab CI

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -338,6 +338,11 @@ final class CustomBuildScanEnhancements {
                 if (branch.isPresent()) {
                     return branch.get();
                 }
+            } else if (isGitLab()){
+                Optional<String> branch = Utils.envVariable("CI_COMMIT_REF_NAME", providers);
+                if (branch.isPresent()) {
+                    return branch.get();
+                }
             }
             return gitCommand.get();
         }
@@ -348,6 +353,10 @@ final class CustomBuildScanEnhancements {
 
         private boolean isHudson() {
             return Utils.envVariable("HUDSON_URL", providers).isPresent();
+        }
+
+        private boolean isGitLab() {
+            return Utils.envVariable("GITLAB_CI", providers).isPresent();
         }
 
     }


### PR DESCRIPTION
Fix for https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/55

Before (Branch tag always HEAD when executed in CI): 
![image](https://user-images.githubusercontent.com/43936658/177409217-8394c61a-e465-4c37-a2c2-92170db7fa46.png)

After:
![image](https://user-images.githubusercontent.com/43936658/177409657-2bee5415-98c9-44d6-bcb3-a8ed4d5a350c.png)


