### PR TITLE
Provide static application method

### DIFF
--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -67,7 +67,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
         // configuration changes applied in this block will override earlier configuration settings,
         // including those set in the settings.gradle(.kts)
-        Action<Settings> settingsAction = __ -> {
+        Action<Settings> settingsAction = ___ -> {
             Overrides overrides = new Overrides(providers);
             overrides.configureGradleEnterprise(gradleEnterprise);
             overrides.configureBuildCache(buildCache);
@@ -155,8 +155,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     private static boolean settingsHaveBeenEvaluated() {
         return Arrays.stream(Thread.currentThread().getStackTrace())
-                .map(StackTraceElement::getMethodName)
-                .anyMatch(s -> s.contains("settingsEvaluated"));
+            .map(StackTraceElement::getMethodName)
+            .anyMatch(s -> s.contains("settingsEvaluated"));
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -45,13 +45,14 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     public static void apply(Object gradleEnterprise, ProviderFactory providers, Settings settings) {
         applySettingsPlugin(
-                ProxyFactory.createProxy(gradleEnterprise, GradleEnterpriseExtension.class),
+                gradleEnterprise,
                 providers,
                 settings
         );
     }
 
-    private static void applySettingsPlugin(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers, Settings settings) {
+    private static void applySettingsPlugin(Object gradleEnterpriseExtension, ProviderFactory providers, Settings settings) {
+        GradleEnterpriseExtension gradleEnterprise = ProxyFactory.createProxy(gradleEnterpriseExtension, GradleEnterpriseExtension.class);
         CustomGradleEnterpriseConfig customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig();
 
         customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
@@ -82,7 +83,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
     }
 
     private void applySettingsPlugin(Settings settings) {
-        settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> applySettingsPlugin(ProxyFactory.createProxy(settings.getExtensions().getByName("gradleEnterprise"), GradleEnterpriseExtension.class), providers, settings));
+        settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> applySettingsPlugin(settings.getExtensions().getByName("gradleEnterprise"), providers, settings));
     }
 
     private void applyProjectPluginGradle5(Project project) {

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -43,9 +43,9 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         }
     }
 
-    public static void apply(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers, Settings settings) {
+    public static void apply(Object gradleEnterprise, ProviderFactory providers, Settings settings) {
         applySettingsPlugin(
-                gradleEnterprise,
+                ProxyFactory.createProxy(gradleEnterprise, GradleEnterpriseExtension.class),
                 providers,
                 settings
         );

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -43,38 +43,46 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         }
     }
 
+    public static void apply(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers, Settings settings) {
+        applySettingsPlugin(
+                gradleEnterprise,
+                providers,
+                settings
+        );
+    }
+
+    private static void applySettingsPlugin(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers, Settings settings) {
+        CustomGradleEnterpriseConfig customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig();
+
+        customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+
+        BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
+        customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle());
+        buildScanEnhancements.apply();
+
+        BuildCacheConfiguration buildCache = settings.getBuildCache();
+        customGradleEnterpriseConfig.configureBuildCache(buildCache);
+
+        // configuration changes applied in this block will override earlier configuration settings,
+        // including those set in the settings.gradle(.kts)
+        Action<Settings> settingsAction = __ -> {
+            Overrides overrides = new Overrides(providers);
+            overrides.configureGradleEnterprise(gradleEnterprise);
+            overrides.configureBuildCache(buildCache);
+        };
+
+        // it is possible that the settings have already been evaluated by now, in which case
+        // a settingsEvaluated callback would not fire anymore
+        if (settingsHaveBeenEvaluated()) {
+            settingsAction.execute(settings);
+        } else {
+            settings.getGradle().settingsEvaluated(settingsAction);
+        }
+    }
+
     private void applySettingsPlugin(Settings settings) {
-        settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
-            CustomGradleEnterpriseConfig customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig();
-
-            Object extension = settings.getExtensions().getByName("gradleEnterprise");
-            GradleEnterpriseExtension gradleEnterprise = ProxyFactory.createProxy(extension, GradleEnterpriseExtension.class);
-            customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
-
-            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle());
-            buildScanEnhancements.apply();
-
-            BuildCacheConfiguration buildCache = settings.getBuildCache();
-            customGradleEnterpriseConfig.configureBuildCache(buildCache);
-
-            // configuration changes applied in this block will override earlier configuration settings,
-            // including those set in the settings.gradle(.kts)
-            Action<Settings> settingsAction = ___ -> {
-                Overrides overrides = new Overrides(providers);
-                overrides.configureGradleEnterprise(gradleEnterprise);
-                overrides.configureBuildCache(buildCache);
-            };
-
-            // it is possible that the settings have already been evaluated by now, in which case
-            // a settingsEvaluated callback would not fire anymore
-            if (settingsHaveBeenEvaluated()) {
-                settingsAction.execute(settings);
-            } else {
-                settings.getGradle().settingsEvaluated(settingsAction);
-            }
-        });
+        settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> applySettingsPlugin(ProxyFactory.createProxy(settings.getExtensions().getByName("gradleEnterprise"), GradleEnterpriseExtension.class), providers, settings));
     }
 
     private void applyProjectPluginGradle5(Project project) {
@@ -144,10 +152,10 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         }
     }
 
-    private boolean settingsHaveBeenEvaluated() {
+    private static boolean settingsHaveBeenEvaluated() {
         return Arrays.stream(Thread.currentThread().getStackTrace())
-            .map(StackTraceElement::getMethodName)
-            .anyMatch(s -> s.contains("settingsEvaluated"));
+                .map(StackTraceElement::getMethodName)
+                .anyMatch(s -> s.contains("settingsEvaluated"));
     }
 
 }


### PR DESCRIPTION
Related to https://github.com/gradle/ge/issues/16749.
See https://github.com/gradle/ge/pull/16816

This changes adds a publicly available **static** `apply` method on the CCUD gradle plugin in order to make its application work in the Gradle Enterprise build.