### PR TITLE
Use Gradle Enterprise build cache node connector

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -23,13 +23,8 @@ buildCache {
         enabled = true
     }
 
-    remote(HttpBuildCache) {
-        url = 'https://ge.solutions-team.gradle.com/cache/'
+    remote(gradleEnterprise.buildCache) {
         allowUntrustedServer = false
-        credentials { creds ->
-            creds.username = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
-            creds.password = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
-        }
         enabled = true
         push = isCI
     }


### PR DESCRIPTION
Very nice: https://ge.solutions-team.gradle.com/s/iqb6mqnsm2aw6/performance/build-cache#remote-cache-use-access-key