### PR TITLE
Fix Intellij tag on IDE syncs

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,2 @@
+- [FIX] Fix Intellij IDEA sync tagged as Android Studio (https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/90) 
+


### PR DESCRIPTION
Favor `idea.vendor.name` system property over `android.injected.invoked.from.ide` which is populated during _Intellij_ and _Android studio_ syncs

fixes https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/90

Signed-off-by: Jerome Prinet <jprinet@gradle.com>