### PR TITLE
Add a link to all build scans with same Jenkins build number and job name

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -450,6 +450,9 @@ final class CustomBuildScanEnhancements {
         }
 
         private void registerLink(String linkLabel, Map<String, String> values) {
+            // the parameters for a link querying multiple custom values look like:
+            // search.names=name1,name2&search.values=value1,value2
+            // this reduction groups all names and all values together in order to properly generate the query
             values.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey()) // results in a deterministic order of link parameters
                 .reduce((a, b) -> new AbstractMap.SimpleEntry<>(a.getKey() + "," + b.getKey(), a.getValue() + "," + b.getValue()))

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -128,7 +128,7 @@ final class CustomBuildScanEnhancements {
                 Map<String, String> params = new LinkedHashMap<>();
                 params.put("CI job", j);
                 params.put("CI build number", b);
-                customValueSearchLinker.registerLink("CI build", params);
+                customValueSearchLinker.registerLink("CI pipeline", params);
             }));
         }
 


### PR DESCRIPTION
Builds on Jenkins commonly run multiple invocations of Gradle, generating multiple build scans. A common question when looking at a build scan is "which other builds ran in this job/pipeline?". Our current custom links do not easily link back to this query in GE.

Currently, there are 4 custom links for a Jenkins build. One of these links back to Jenkins (based on `BUILD_URL`). The other three link back to custom value searches as follows:

- All CI builds run on a given node (based on `NODE_NAME`)
- All CI builds with a particular job name (based on `JOB_NAME`)
- All CI builds with a particular stage name (based on `STAGE_NAME`)
 
We also capture as a custom value the `BUILD_NUMBER` environment variable as `CI build number`. This CI build number correlates to one run of the pipeline, but the numbers are not unique across all pipelines. So, for example, two distinct pipelines may use `1` as the build number for their first build. So a filter only on `BUILD_NUMBER` may show builds from 2 separate pipelines.

This PR adds a custom link to the list of build scans filtered by _both_ `JOB_NAME` and `BUILD_NUMBER` called "CI build build scans" so that a user can easily see the other builds scans from a particular build in Jenkins.

See https://ge.solutions-team.gradle.com/s/4yg2e7i6ea6ua for an example.