### PR TITLE
Preserve overridden shard when also overriding remote cache URL

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
 - [NEW] Add a link to all build scans with same Jenkins build number and job name #95
+- [FIX] Preserve overridden shard when also overriding remote cache URL

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -61,8 +61,8 @@ final class Overrides {
         // Do nothing in case of another build cache type like AWS S3 being used
         if (buildCache.getRemote() instanceof HttpBuildCache) {
             buildCache.remote(HttpBuildCache.class, remote -> {
-                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), shard)));
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).ifPresent(remote::setUrl);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), shard)));
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_PUSH, providers).ifPresent(remote::setPush);


### PR DESCRIPTION
This change re-orders the overrides for remote cache url and shard. Before this change, both overriding the url and setting a shard would result in the specified shard being discarded. After this change, a user can specify both a url override and a shard and have the two properly set together.