### PR TITLE
Allow overrides to apply to Gradle Enterprise build cache connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ to modify the build scripts. For example, to disable the local build cache when 
 <details>
   <summary>Click to see the complete set of available system properties and environment variables in the table below. </summary>
 
-### Gradle Enterprise Settings
+### Gradle Enterprise settings
 
 | Gradle Enterprise API                 | System property                        | Environment variable                   |
 |:--------------------------------------|:---------------------------------------|:---------------------------------------|
 | gradleEnterprise.server               | gradle.enterprise.url                  | GRADLE_ENTERPRISE_URL                  |
 | gradleEnterprise.allowUntrustedServer | gradle.enterprise.allowUntrustedServer | GRADLE_ENTERPRISE_ALLOWUNTRUSTEDSERVER |
 
-### Local Build Cache Settings
+### Local Build Cache settings
 
 | Local Build Cache API                            | System property                                 | Environment variable                            |
 |:-------------------------------------------------|:------------------------------------------------|:------------------------------------------------|
@@ -85,25 +85,27 @@ to modify the build scripts. For example, to disable the local build cache when 
 | buildCache.local.setDirectory                    | gradle.cache.local.directory                    | GRADLE_CACHE_LOCAL_DIRECTORY                    |
 | buildCache.local.setRemoveUnusedEntriesAfterDays | gradle.cache.local.removeUnusedEntriesAfterDays | GRADLE_CACHE_LOCAL_REMOVEUNUSEDENTRIESAFTERDAYS |
 
-### Gradle Enterprise Build Cache Settings
+### HTTP Build Cache settings
+
+| HTTP Build Cache API                      | System property                          | Environment variable                     |
+|:------------------------------------------|:-----------------------------------------|:-----------------------------------------|
+| buildCache.remote.setEnabled              | gradle.cache.remote.enabled              | GRADLE_CACHE_REMOTE_ENABLED              |
+| buildCache.remote.setPush                 | gradle.cache.remote.push                 | GRADLE_CACHE_REMOTE_PUSH                 |
+| buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
+| buildCache.remote.setUrl                  | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
+| buildCache.remote.setUrl                  | gradle.cache.remote.path                 | GRADLE_CACHE_REMOTE_PATH                 |
+| buildCache.remote.setUrl                  | gradle.cache.remote.shard                | GRADLE_CACHE_REMOTE_SHARD                |
+
+### Gradle Enterprise Build Cache settings
 
 | Gradle Enterprise Build Cache API         | System property                          | Environment variable                     |
 |:------------------------------------------|:-----------------------------------------|:-----------------------------------------|
 | buildCache.remote.setEnabled              | gradle.cache.remote.enabled              | GRADLE_CACHE_REMOTE_ENABLED              |
 | buildCache.remote.setPush                 | gradle.cache.remote.push                 | GRADLE_CACHE_REMOTE_PUSH                 |
+| buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
 | buildCache.remote.setServer               | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
-| buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
+| buildCache.remote.setPath                 | gradle.cache.remote.path                 | GRADLE_CACHE_REMOTE_PATH                 |
 | buildCache.remote.setPath                 | gradle.cache.remote.shard                | GRADLE_CACHE_REMOTE_SHARD                |
-
-### HTTP Build Cache Settings
-
-| HTTP Build Cache API                      | System property                          | Environment variable                    |
-|:------------------------------------------|:-----------------------------------------|:-----------------------------------------|
-| buildCache.remote.setEnabled              | gradle.cache.remote.enabled              | GRADLE_CACHE_REMOTE_ENABLED              |
-| buildCache.remote.setPush                 | gradle.cache.remote.push                 | GRADLE_CACHE_REMOTE_PUSH                 |
-| buildCache.remote.setUrl                  | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
-| buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
-| ---                                       | gradle.cache.remote.shard                | GRADLE_CACHE_REMOTE_SHARD                |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -69,19 +69,42 @@ to modify the build scripts. For example, to disable the local build cache when 
 <details>
   <summary>Click to see the complete set of available system properties and environment variables in the table below. </summary>
 
-| Gradle Enterprise / Build Cache API | System property | Environment variable |
-| :-------------- | :-------------  | :------------------- |
-|gradleEnterprise.server|gradle.enterprise.url|GRADLE_ENTERPRISE_URL|
-|gradleEnterprise.allowUntrustedServer|gradle.enterprise.allowUntrustedServer|GRADLE_ENTERPRISE_ALLOWUNTRUSTEDSERVER|
-|buildCache.local.setEnabled|gradle.cache.local.enabled|GRADLE_CACHE_LOCAL_ENABLED|
-|buildCache.local.setPush|gradle.cache.local.push|GRADLE_CACHE_LOCAL_PUSH|
-|buildCache.local.setDirectory|gradle.cache.local.directory|GRADLE_CACHE_LOCAL_DIRECTORY|
-|buildCache.local.setRemoveUnusedEntriesAfterDays|gradle.cache.local.removeUnusedEntriesAfterDays|GRADLE_CACHE_LOCAL_REMOVEUNUSEDENTRIESAFTERDAYS|
-|buildCache.remote.setEnabled|gradle.cache.remote.enabled|GRADLE_CACHE_REMOTE_ENABLED|
-|buildCache.remote.setPush|gradle.cache.remote.push|GRADLE_CACHE_REMOTE_PUSH|
-|buildCache.remote.setUrl|gradle.cache.remote.url|GRADLE_CACHE_REMOTE_URL|
-|buildCache.remote.setAllowUntrustedServer|gradle.cache.remote.allowUntrustedServer|GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER|
-|---|gradle.cache.remote.shard|GRADLE_CACHE_REMOTE_SHARD|
+### Gradle Enterprise Settings
+
+| Gradle Enterprise API                 | System property                        | Environment variable                   |
+|:--------------------------------------|:---------------------------------------|:---------------------------------------|
+| gradleEnterprise.server               | gradle.enterprise.url                  | GRADLE_ENTERPRISE_URL                  |
+| gradleEnterprise.allowUntrustedServer | gradle.enterprise.allowUntrustedServer | GRADLE_ENTERPRISE_ALLOWUNTRUSTEDSERVER |
+
+### Local Build Cache Settings
+
+| Local Build Cache API                            | System property                                 | Environment variable                            |
+|:-------------------------------------------------|:------------------------------------------------|:------------------------------------------------|
+| buildCache.local.setEnabled                      | gradle.cache.local.enabled                      | GRADLE_CACHE_LOCAL_ENABLED                      |
+| buildCache.local.setPush                         | gradle.cache.local.push                         | GRADLE_CACHE_LOCAL_PUSH                         |
+| buildCache.local.setDirectory                    | gradle.cache.local.directory                    | GRADLE_CACHE_LOCAL_DIRECTORY                    |
+| buildCache.local.setRemoveUnusedEntriesAfterDays | gradle.cache.local.removeUnusedEntriesAfterDays | GRADLE_CACHE_LOCAL_REMOVEUNUSEDENTRIESAFTERDAYS |
+
+### Gradle Enterprise Build Cache Settings
+
+| Gradle Enterprise Build Cache API         | System property                          | Environment variable                     |
+|:------------------------------------------|:-----------------------------------------|:-----------------------------------------|
+| buildCache.remote.setEnabled              | gradle.cache.remote.enabled              | GRADLE_CACHE_REMOTE_ENABLED              |
+| buildCache.remote.setPush                 | gradle.cache.remote.push                 | GRADLE_CACHE_REMOTE_PUSH                 |
+| buildCache.remote.setServer               | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
+| buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
+| buildCache.remote.setPath                 | gradle.cache.remote.shard                | GRADLE_CACHE_REMOTE_SHARD                |
+
+### HTTP Build Cache Settings
+
+| HTTP Build Cache API                      | System property                          | Environment variable                    |
+|:------------------------------------------|:-----------------------------------------|:-----------------------------------------|
+| buildCache.remote.setEnabled              | gradle.cache.remote.enabled              | GRADLE_CACHE_REMOTE_ENABLED              |
+| buildCache.remote.setPush                 | gradle.cache.remote.push                 | GRADLE_CACHE_REMOTE_PUSH                 |
+| buildCache.remote.setUrl                  | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
+| buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
+| ---                                       | gradle.cache.remote.shard                | GRADLE_CACHE_REMOTE_SHARD                |
+
 </details>
 
 ## Developing a customized version of the plugin

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
 - [NEW] Add a link to all build scans with same Jenkins build number and job name #95
+- [FIX] - Support overrides to GradleEnterpriseBuildCache connector

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 import static com.gradle.Utils.appendPathAndTrailingSlash;
+import static com.gradle.Utils.concatenatePaths;
 
 /**
  * Provide standardized Gradle Enterprise configuration. By applying the plugin, these settings will automatically be applied.
@@ -28,8 +29,9 @@ final class Overrides {
     static final String LOCAL_CACHE_PUSH = "gradle.cache.local.push";
 
     // system properties to override remote build cache configuration
-    static final String REMOTE_CACHE_SHARD = "gradle.cache.remote.shard";
     static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
+    static final String REMOTE_CACHE_PATH = "gradle.cache.remote.path";
+    static final String REMOTE_CACHE_SHARD = "gradle.cache.remote.shard";
     static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
     static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
     static final String REMOTE_CACHE_PUSH = "gradle.cache.remote.push";
@@ -62,18 +64,18 @@ final class Overrides {
         // Do nothing in case of another build cache type like AWS S3 being used
         if (buildCache.getRemote() instanceof HttpBuildCache) {
             buildCache.remote(HttpBuildCache.class, remote -> {
-                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), shard)));
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).ifPresent(remote::setUrl);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(path -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), path)));
+                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), shard)));
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_PUSH, providers).ifPresent(remote::setPush);
             });
-        }
-
-        if (buildCache.getRemote() instanceof GradleEnterpriseBuildCache) {
+        } else if (buildCache.getRemote() instanceof GradleEnterpriseBuildCache) {
             buildCache.remote(GradleEnterpriseBuildCache.class, remote -> {
-                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> "cache/" + shard).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).ifPresent(remote::setServer);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(remote::setPath);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setPath(concatenatePaths(remote.getPath(), shard)));
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_PUSH, providers).ifPresent(remote::setPush);

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -105,6 +105,18 @@ final class Utils {
         return baseUri;
     }
 
+    static String concatenatePaths(String basePath, String path) {
+        if (isNotEmpty(basePath)) {
+            if (isNotEmpty(path)) {
+                String normalizedBasePath = appendIfMissing(basePath, "/");
+                String normalizedPath = stripPrefix("/", path);
+                return normalizedBasePath + normalizedPath;
+            }
+            return basePath;
+        }
+        return path;
+    }
+
     static String urlEncode(String str) {
         try {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());


### PR DESCRIPTION
Currently, environment variable/system property overrides only the HTTP build cache settings. This pull request adds conditional logic to also apply the same overrides to a project that utilizes the Gradle Enterprise build cache connector.