### PR TITLE
Upgrade some Github actions to get rid of deprecation warnings

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -15,7 +15,7 @@ jobs:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git config --global url."https://unused-username:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb4264d3319acaa2bea23d51ef67f80b4f775013
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549
         with:
           gpg_private_key: ${{ secrets.GH_BOT_PGP_PRIVATE_KEY }}
           passphrase: ${{ secrets.GH_BOT_PGP_PASSPHRASE }}


### PR DESCRIPTION
- Upgrade crazy-max/ghaction-import-gpg to latest
- Upgrade actions/setup-java to v3

