### PR TITLE
Move captureCiMetadata to execution phase

### DIFF
--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -1,5 +1,6 @@
 package com.gradle;
 
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
@@ -136,8 +137,8 @@ final class Utils {
         }
     }
 
-    static Properties readPropertiesFile(String name, ProviderFactory providers, Gradle gradle) {
-        try (InputStream input = readFile(name, providers, gradle)) {
+    static Properties readPropertiesFile(String name, ProviderFactory providers, Directory projectDirectory) {
+        try (InputStream input = readFile(name, providers, projectDirectory)) {
             Properties properties = new Properties();
             properties.load(input);
             return properties;
@@ -146,9 +147,9 @@ final class Utils {
         }
     }
 
-    static InputStream readFile(String name, ProviderFactory providers, Gradle gradle) throws FileNotFoundException {
+    static InputStream readFile(String name, ProviderFactory providers, Directory projectDirectory) throws FileNotFoundException {
         if (isGradle65OrNewer()) {
-            RegularFile file = gradle.getRootProject().getLayout().getProjectDirectory().file(name);
+            RegularFile file = projectDirectory.file(name);
             Provider<byte[]> fileContent = providers.fileContents(file).getAsBytes();
             if (!isGradle74OrNewer()) {
                 fileContent = fileContent.forUseAtConfigurationTime();


### PR DESCRIPTION
The PR aims to capture CI metadata at execution time (in a `buildFinished` block) not to invalidate configuration cache on CI metadata change (ie. `build number`)

Teamcity data are now fetched from a teamcity generated build file because project properties set in an init file can't easily be read at execution time through a [Provider](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/ProviderFactory.html#gradleProperty-java.lang.String-) due to [this issue](https://github.com/gradle/gradle/issues/23572).

The `projectEvaluated` callback has been replaced with a `afterProject` callback. The latter is called even in case of a configuration cache entry restored.

Note that Teamcity is not yet compatible with configuration cache due to [this](https://youtrack.jetbrains.com/issue/TW-71916)

fixes #80 

Signed-off-by: Jerome Prinet <jprinet@gradle.com>