### PR TITLE
Jprinet/move logic to execution time

### DIFF
--- a/src/main/java/com/gradle/CiUtils.java
+++ b/src/main/java/com/gradle/CiUtils.java
@@ -1,0 +1,71 @@
+package com.gradle;
+
+import org.gradle.api.provider.ProviderFactory;
+
+final class CiUtils {
+
+    static boolean isCi(ProviderFactory providers) {
+        return isGenericCI(providers)
+                || isJenkins(providers)
+                || isHudson(providers)
+                || isTeamCity(providers)
+                || isCircleCI(providers)
+                || isBamboo(providers)
+                || isGitHubActions(providers)
+                || isGitLab(providers)
+                || isTravis(providers)
+                || isBitrise(providers)
+                || isGoCD(providers)
+                || isAzurePipelines(providers);
+    }
+
+    static boolean isGenericCI(ProviderFactory providers) {
+        return Utils.envVariable("CI", providers).isPresent()
+                || Utils.sysProperty("CI", providers).isPresent();
+    }
+
+    static boolean isJenkins(ProviderFactory providers) {
+        return Utils.envVariable("JENKINS_URL", providers).isPresent();
+    }
+
+    static boolean isHudson(ProviderFactory providers) {
+        return Utils.envVariable("HUDSON_URL", providers).isPresent();
+    }
+
+    static boolean isTeamCity(ProviderFactory providers) {
+        return Utils.envVariable("TEAMCITY_VERSION", providers).isPresent();
+    }
+
+    static boolean isCircleCI(ProviderFactory providers) {
+        return Utils.envVariable("CIRCLE_BUILD_URL", providers).isPresent();
+    }
+
+    static boolean isBamboo(ProviderFactory providers) {
+        return Utils.envVariable("bamboo_resultsUrl", providers).isPresent();
+    }
+
+    static boolean isGitHubActions(ProviderFactory providers) {
+        return Utils.envVariable("GITHUB_ACTIONS", providers).isPresent();
+    }
+
+    static boolean isGitLab(ProviderFactory providers) {
+        return Utils.envVariable("GITLAB_CI", providers).isPresent();
+    }
+
+    static boolean isTravis(ProviderFactory providers) {
+        return Utils.envVariable("TRAVIS_JOB_ID", providers).isPresent();
+    }
+
+    static boolean isBitrise(ProviderFactory providers) {
+        return Utils.envVariable("BITRISE_BUILD_URL", providers).isPresent();
+    }
+
+    static boolean isGoCD(ProviderFactory providers) {
+        return Utils.envVariable("GO_SERVER_URL", providers).isPresent();
+    }
+
+    static boolean isAzurePipelines(ProviderFactory providers) {
+        return Utils.envVariable("TF_BUILD", providers).isPresent();
+    }
+
+}

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -9,7 +9,6 @@ import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
-import org.gradle.util.GradleVersion;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -25,17 +24,17 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     public void apply(Object target) {
         if (target instanceof Settings) {
-            if (!isGradle6OrNewer()) {
+            if (!Utils.isGradle6OrNewer()) {
                 throw new GradleException("For Gradle versions prior to 6.0, common-custom-user-data-gradle-plugin must be applied to the Root project");
             } else {
                 applySettingsPlugin((Settings) target);
             }
         } else if (target instanceof Project) {
-            if (isGradle6OrNewer()) {
+            if (Utils.isGradle6OrNewer()) {
                 throw new GradleException("For Gradle versions 6.0 and newer, common-custom-user-data-gradle-plugin must be applied to Settings");
-            } else if (isGradle5OrNewer()) {
+            } else if (Utils.isGradle5OrNewer()) {
                 applyProjectPluginGradle5((Project) target);
-            } else if (isGradle4OrNewer()) {
+            } else if (Utils.isGradle4OrNewer()) {
                 applyProjectPluginGradle4((Project) target);
             } else {
                 throw new GradleException("For Gradle versions prior to 4.0, common-custom-user-data-gradle-plugin is not supported");
@@ -133,18 +132,6 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
                 overrides.configureGradleEnterpriseOnGradle4(buildScan);
             });
         });
-    }
-
-    private static boolean isGradle6OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("6.0")) >= 0;
-    }
-
-    private static boolean isGradle5OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0;
-    }
-
-    private static boolean isGradle4OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("4.0")) >= 0;
     }
 
     private static void ensureRootProject(Project project) {

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -1,7 +1,7 @@
 package com.gradle;
 
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.util.GradleVersion;
@@ -26,16 +26,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 final class Utils {
-
-    static Optional<String> projectProperty(String name, ProviderFactory providers, Gradle gradle) {
-        if (isGradle65OrNewer() && !isGradle74OrNewer()) {
-            // invalidate configuration cache if different Gradle property value is set on the cmd line,
-            // but in any case access Gradle property directly since project properties set in a build script or
-            // init script are not fetched by ProviderFactory.gradleProperty
-            providers.gradleProperty(name).forUseAtConfigurationTime();
-        }
-        return Optional.ofNullable((String) gradle.getRootProject().findProperty(name));
-    }
 
     static Optional<String> sysPropertyOrEnvVariable(String sysPropertyName, String envVarName, ProviderFactory providers) {
         Optional<String> sysProperty = sysProperty(sysPropertyName, providers);
@@ -136,8 +126,8 @@ final class Utils {
         }
     }
 
-    static Properties readPropertiesFile(String name, ProviderFactory providers, Gradle gradle) {
-        try (InputStream input = readFile(name, providers, gradle)) {
+    static Properties readPropertiesFile(String name, ProviderFactory providers, Directory projectDirectory) {
+        try (InputStream input = readFile(name, providers, projectDirectory)) {
             Properties properties = new Properties();
             properties.load(input);
             return properties;
@@ -146,13 +136,10 @@ final class Utils {
         }
     }
 
-    static InputStream readFile(String name, ProviderFactory providers, Gradle gradle) throws FileNotFoundException {
+    static InputStream readFile(String name, ProviderFactory providers, Directory projectDirectory) throws FileNotFoundException {
         if (isGradle65OrNewer()) {
-            RegularFile file = gradle.getRootProject().getLayout().getProjectDirectory().file(name);
+            RegularFile file = projectDirectory.file(name);
             Provider<byte[]> fileContent = providers.fileContents(file).getAsBytes();
-            if (!isGradle74OrNewer()) {
-                fileContent = fileContent.forUseAtConfigurationTime();
-            }
             return new ByteArrayInputStream(fileContent.getOrElse(new byte[0]));
         }
         return new FileInputStream(name);
@@ -212,12 +199,36 @@ final class Utils {
         return ('x' + str).trim().substring(1);
     }
 
-    private static boolean isGradle65OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0;
+    static boolean isGradle4OrNewer() {
+        return isGradleNewerThan("4.0");
     }
 
-    private static boolean isGradle74OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("7.4")) >= 0;
+    static boolean isGradle5OrNewer() {
+        return isGradleNewerThan("5.0");
+    }
+
+    static boolean isGradle6OrNewer() {
+        return isGradleNewerThan("6.0");
+    }
+
+    static boolean isGradle61OrNewer() {
+        return isGradleNewerThan("6.1");
+    }
+
+    static boolean isGradle62OrNewer() {
+        return isGradleNewerThan("6.2");
+    }
+
+    static boolean isGradle65OrNewer() {
+        return isGradleNewerThan("6.5");
+    }
+
+    static boolean isGradle74OrNewer() {
+        return isGradleNewerThan("7.4");
+    }
+
+    private static boolean isGradleNewerThan(String version) {
+        return GradleVersion.current().compareTo(GradleVersion.version(version)) >= 0;
     }
 
     private Utils() {


### PR DESCRIPTION
The PR aims to capture CI and IDE metadata at execution time (in a `buildFinished` block), therefore preventing configuration cache invalidation if a property changes (ie. `CI build number`)

Teamcity data are now fetched from a teamcity generated build file because project properties set in an init file can't easily be read at execution time through a [Provider](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/ProviderFactory.html#gradleProperty-java.lang.String-) due to https://github.com/gradle/gradle/issues/23572.

The `projectEvaluated` callback has been replaced by `Providers` used at execution time in order to fix configuration cache restore scenarii.

Note that Teamcity is not yet compatible with configuration cache due to [this](https://youtrack.jetbrains.com/issue/TW-71916)

fixes https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/80

Signed-off-by: Jerome Prinet [jprinet@gradle.com](mailto:jprinet@gradle.com)