### PR TITLE
Move CI and IDE metadata processing at execution time

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,4 @@
 - [NEW] Add a link to all build scans with same Jenkins build number and job name #95
-- [FIX] - Support overrides to GradleEnterpriseBuildCache connector
+- [FIX] Support overrides to GradleEnterpriseBuildCache connector
+- [FIX] Move CI and IDE metadata processing at execution time (https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/80) 
+

--- a/src/main/java/com/gradle/CiUtils.java
+++ b/src/main/java/com/gradle/CiUtils.java
@@ -2,6 +2,9 @@ package com.gradle;
 
 import org.gradle.api.provider.ProviderFactory;
 
+import static com.gradle.Utils.envVariable;
+import static com.gradle.Utils.sysProperty;
+
 final class CiUtils {
 
     private CiUtils() {
@@ -23,52 +26,52 @@ final class CiUtils {
     }
 
     static boolean isGenericCI(ProviderFactory providers) {
-        return Utils.envVariable("CI", providers).isPresent()
-                || Utils.sysProperty("CI", providers).isPresent();
+        return envVariable("CI", providers).isPresent()
+                || sysProperty("CI", providers).isPresent();
     }
 
     static boolean isJenkins(ProviderFactory providers) {
-        return Utils.envVariable("JENKINS_URL", providers).isPresent();
+        return envVariable("JENKINS_URL", providers).isPresent();
     }
 
     static boolean isHudson(ProviderFactory providers) {
-        return Utils.envVariable("HUDSON_URL", providers).isPresent();
+        return envVariable("HUDSON_URL", providers).isPresent();
     }
 
     static boolean isTeamCity(ProviderFactory providers) {
-        return Utils.envVariable("TEAMCITY_VERSION", providers).isPresent();
+        return envVariable("TEAMCITY_VERSION", providers).isPresent();
     }
 
     static boolean isCircleCI(ProviderFactory providers) {
-        return Utils.envVariable("CIRCLE_BUILD_URL", providers).isPresent();
+        return envVariable("CIRCLE_BUILD_URL", providers).isPresent();
     }
 
     static boolean isBamboo(ProviderFactory providers) {
-        return Utils.envVariable("bamboo_resultsUrl", providers).isPresent();
+        return envVariable("bamboo_resultsUrl", providers).isPresent();
     }
 
     static boolean isGitHubActions(ProviderFactory providers) {
-        return Utils.envVariable("GITHUB_ACTIONS", providers).isPresent();
+        return envVariable("GITHUB_ACTIONS", providers).isPresent();
     }
 
     static boolean isGitLab(ProviderFactory providers) {
-        return Utils.envVariable("GITLAB_CI", providers).isPresent();
+        return envVariable("GITLAB_CI", providers).isPresent();
     }
 
     static boolean isTravis(ProviderFactory providers) {
-        return Utils.envVariable("TRAVIS_JOB_ID", providers).isPresent();
+        return envVariable("TRAVIS_JOB_ID", providers).isPresent();
     }
 
     static boolean isBitrise(ProviderFactory providers) {
-        return Utils.envVariable("BITRISE_BUILD_URL", providers).isPresent();
+        return envVariable("BITRISE_BUILD_URL", providers).isPresent();
     }
 
     static boolean isGoCD(ProviderFactory providers) {
-        return Utils.envVariable("GO_SERVER_URL", providers).isPresent();
+        return envVariable("GO_SERVER_URL", providers).isPresent();
     }
 
     static boolean isAzurePipelines(ProviderFactory providers) {
-        return Utils.envVariable("TF_BUILD", providers).isPresent();
+        return envVariable("TF_BUILD", providers).isPresent();
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -9,7 +9,6 @@ import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
-import org.gradle.util.GradleVersion;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -25,17 +24,17 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     public void apply(Object target) {
         if (target instanceof Settings) {
-            if (!isGradle6OrNewer()) {
+            if (!Utils.isGradle6OrNewer()) {
                 throw new GradleException("For Gradle versions prior to 6.0, common-custom-user-data-gradle-plugin must be applied to the Root project");
             } else {
                 applySettingsPlugin((Settings) target);
             }
         } else if (target instanceof Project) {
-            if (isGradle6OrNewer()) {
+            if (Utils.isGradle6OrNewer()) {
                 throw new GradleException("For Gradle versions 6.0 and newer, common-custom-user-data-gradle-plugin must be applied to Settings");
-            } else if (isGradle5OrNewer()) {
+            } else if (Utils.isGradle5OrNewer()) {
                 applyProjectPluginGradle5((Project) target);
-            } else if (isGradle4OrNewer()) {
+            } else if (Utils.isGradle4OrNewer()) {
                 applyProjectPluginGradle4((Project) target);
             } else {
                 throw new GradleException("For Gradle versions prior to 4.0, common-custom-user-data-gradle-plugin is not supported");
@@ -133,18 +132,6 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
                 overrides.configureGradleEnterpriseOnGradle4(buildScan);
             });
         });
-    }
-
-    private static boolean isGradle6OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("6.0")) >= 0;
-    }
-
-    private static boolean isGradle5OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0;
-    }
-
-    private static boolean isGradle4OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("4.0")) >= 0;
     }
 
     private static void ensureRootProject(Project project) {

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -13,6 +13,10 @@ import org.gradle.caching.configuration.BuildCacheConfiguration;
 import javax.inject.Inject;
 import java.util.Arrays;
 
+import static com.gradle.Utils.isGradle4OrNewer;
+import static com.gradle.Utils.isGradle5OrNewer;
+import static com.gradle.Utils.isGradle6OrNewer;
+
 public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     private final ProviderFactory providers;
@@ -24,17 +28,17 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     public void apply(Object target) {
         if (target instanceof Settings) {
-            if (!Utils.isGradle6OrNewer()) {
+            if (!isGradle6OrNewer()) {
                 throw new GradleException("For Gradle versions prior to 6.0, common-custom-user-data-gradle-plugin must be applied to the Root project");
             } else {
                 applySettingsPlugin((Settings) target);
             }
         } else if (target instanceof Project) {
-            if (Utils.isGradle6OrNewer()) {
+            if (isGradle6OrNewer()) {
                 throw new GradleException("For Gradle versions 6.0 and newer, common-custom-user-data-gradle-plugin must be applied to Settings");
-            } else if (Utils.isGradle5OrNewer()) {
+            } else if (isGradle5OrNewer()) {
                 applyProjectPluginGradle5((Project) target);
-            } else if (Utils.isGradle4OrNewer()) {
+            } else if (isGradle4OrNewer()) {
                 applyProjectPluginGradle4((Project) target);
             } else {
                 throw new GradleException("For Gradle versions prior to 4.0, common-custom-user-data-gradle-plugin is not supported");

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -224,11 +224,11 @@ final class CustomBuildScanEnhancements {
                     }
                     String teamCityBuildTypeId = buildProperties.getProperty("teamcity.buildType.id");
                     if (Utils.isNotEmpty(teamCityBuildTypeId)) {
-                        buildScan.value("CI build config", teamCityBuildTypeId);
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI build config", teamCityBuildTypeId);
                     }
                     String teamCityAgentName = buildProperties.getProperty("agent.name");
                     if (Utils.isNotEmpty(teamCityAgentName)) {
-                        buildScan.value("CI agent", teamCityAgentName);
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI agent", teamCityAgentName);
                     }
                 }
             }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -234,15 +234,17 @@ final class CustomBuildScanEnhancements {
                 if (teamcityBuildPropertiesFile.isPresent()) {
                     Properties buildProperties = readPropertiesFile(teamcityBuildPropertiesFile.get(), providers, projectDirectory.get());
 
-                    String teamcityConfigFile = buildProperties.getProperty("teamcity.configuration.properties.file");
-                    if (isNotEmpty(teamcityConfigFile)) {
-                        Properties configProperties = readPropertiesFile(teamcityConfigFile, providers, projectDirectory.get());
+                    String teamCityBuildId = buildProperties.getProperty("teamcity.build.id");
+                    if(isNotEmpty(teamCityBuildId)) {
+                        String teamcityConfigFile = buildProperties.getProperty("teamcity.configuration.properties.file");
+                        if (isNotEmpty(teamcityConfigFile)) {
+                            Properties configProperties = readPropertiesFile(teamcityConfigFile, providers, projectDirectory.get());
 
-                        String teamCityServerUrl = configProperties.getProperty("teamcity.serverUrl");
-                        String teamCityBuildId = buildProperties.getProperty("teamcity.build.id");
-                        if (isNotEmpty(teamCityServerUrl) && isNotEmpty(teamCityBuildId)) {
-                            String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildId=" + urlEncode(teamCityBuildId);
-                            buildScan.link("TeamCity build", buildUrl);
+                            String teamCityServerUrl = configProperties.getProperty("teamcity.serverUrl");
+                            if (isNotEmpty(teamCityServerUrl)) {
+                                String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildId=" + urlEncode(teamCityBuildId);
+                                buildScan.link("TeamCity build", buildUrl);
+                            }
                         }
                     }
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -115,13 +115,13 @@ final class CustomBuildScanEnhancements {
                 String ideaVendorNameValue = props.get(SYSTEM_PROP_IDEA_VENDOR_NAME).get();
                 if (ideaVendorNameValue.equals("Google")) {
                     // using androidStudioVersion instead of ideaVersion for compatibility reasons, those can be different (e.g. 2020.3.1 Patch 3 instead of 2020.3)
-                    tagIde("Android Studio", props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION).getOrElse(""));
+                    tagIde("Android Studio", getOrEmpty(props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION)));
                 } else if (ideaVendorNameValue.equals("JetBrains")) {
-                    tagIde("IntelliJ IDEA", props.get(SYSTEM_PROP_IDEA_VERSION).getOrElse(""));
+                    tagIde("IntelliJ IDEA", getOrEmpty(props.get(SYSTEM_PROP_IDEA_VERSION)));
                 }
             } else if (props.get(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE).isPresent()) {
                 // this case should be handled by the ideaVendorName condition but keeping it for compatibility reason (ideaVendorName started with 2020.1)
-                tagIde("Android Studio", props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION).getOrElse(""));
+                tagIde("Android Studio", getOrEmpty(props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION)));
             } else if (props.get(SYSTEM_PROP_IDEA_VERSION).isPresent()) {
                 // this case should be handled by the ideaVendorName condition but keeping it for compatibility reason (ideaVendorName started with 2020.1)
                 tagIde("IntelliJ IDEA", props.get(SYSTEM_PROP_IDEA_VERSION).get());
@@ -133,6 +133,15 @@ final class CustomBuildScanEnhancements {
 
             if (props.get(SYSTEM_PROP_IDEA_SYNC_ACTIVE).isPresent()) {
                 buildScan.tag("IDE sync");
+            }
+        }
+
+        private String getOrEmpty(Provider<String> p) {
+            if (Utils.isGradle43rNewer()) {
+                return p.getOrElse("");
+            } else {
+                String value = p.getOrNull();
+                return value != null ? value : "";
             }
         }
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -84,7 +84,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private Provider<String> systemPropertyProvider(String name, ProviderFactory providers) {
-        if(Utils.isGradle61OrNewer()) {
+        if (Utils.isGradle61OrNewer()) {
             return providers.systemProperty(name);
         } else {
             return providers.provider(() -> System.getProperty(name));
@@ -92,7 +92,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private Provider<String> gradlePropertyProvider(String name, ProviderFactory providers) {
-        if(Utils.isGradle62OrNewer()) {
+        if (Utils.isGradle62OrNewer()) {
             return providers.gradleProperty(name);
         } else {
             return providers.provider(() -> (String) gradle.getRootProject().findProperty(name));
@@ -201,13 +201,13 @@ final class CustomBuildScanEnhancements {
                 }));
             }
 
-            if(CiUtils.isTeamCity(providers)) {
+            if (CiUtils.isTeamCity(providers)) {
                 Optional<String> teamcityBuildPropertiesFile = Utils.envVariable("TEAMCITY_BUILD_PROPERTIES_FILE", providers);
-                if(teamcityBuildPropertiesFile.isPresent()){
+                if (teamcityBuildPropertiesFile.isPresent()) {
                     Properties buildProperties = Utils.readPropertiesFile(teamcityBuildPropertiesFile.get(), providers, projectDirectory.get());
 
                     String teamcityConfigFile = buildProperties.getProperty("teamcity.configuration.properties.file");
-                    if(Utils.isNotEmpty(teamcityConfigFile)) {
+                    if (Utils.isNotEmpty(teamcityConfigFile)) {
                         Properties configProperties = Utils.readPropertiesFile(teamcityConfigFile, providers, projectDirectory.get());
 
                         String teamCityServerUrl = configProperties.getProperty("teamcity.serverUrl");
@@ -321,7 +321,7 @@ final class CustomBuildScanEnhancements {
                         customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
             }
 
-            if(CiUtils.isAzurePipelines(providers)) {
+            if (CiUtils.isAzurePipelines(providers)) {
                 Optional<String> azureServerUrl = Utils.envVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", providers);
                 Optional<String> azureProject = Utils.envVariable("SYSTEM_TEAMPROJECT", providers);
                 Optional<String> buildId = Utils.envVariable("BUILD_BUILDID", providers);
@@ -467,9 +467,9 @@ final class CustomBuildScanEnhancements {
             // search.names=name1,name2&search.values=value1,value2
             // this reduction groups all names and all values together in order to properly generate the query
             values.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey()) // results in a deterministic order of link parameters
-                .reduce((a, b) -> new AbstractMap.SimpleEntry<>(a.getKey() + "," + b.getKey(), a.getValue() + "," + b.getValue()))
-                .ifPresent(x -> registerLink(linkLabel, x.getKey(), x.getValue()));
+                    .sorted(Map.Entry.comparingByKey()) // results in a deterministic order of link parameters
+                    .reduce((a, b) -> new AbstractMap.SimpleEntry<>(a.getKey() + "," + b.getKey(), a.getValue() + "," + b.getValue()))
+                    .ifPresent(x -> registerLink(linkLabel, x.getKey(), x.getValue()));
         }
 
         private synchronized void registerLink(String linkLabel, String name, String value) {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -77,16 +77,16 @@ final class CustomBuildScanEnhancements {
     private void captureIde() {
         if (!CiUtils.isCi(providers)) {
             // Prepare relevant properties for use at execution time
-            Map<String, Provider<String>> relevantProperties = new HashMap<>();
-            relevantProperties.put(SYSTEM_PROP_IDEA_VENDOR_NAME, systemPropertyProvider(SYSTEM_PROP_IDEA_VENDOR_NAME, providers));
-            relevantProperties.put(SYSTEM_PROP_IDEA_VERSION, systemPropertyProvider(SYSTEM_PROP_IDEA_VERSION, providers));
-            relevantProperties.put(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE, gradlePropertyProvider(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE, providers));
-            relevantProperties.put(PROJECT_PROP_ANDROID_STUDIO_VERSION, gradlePropertyProvider(PROJECT_PROP_ANDROID_STUDIO_VERSION, providers));
-            relevantProperties.put(SYSTEM_PROP_ECLIPSE_BUILD_ID, systemPropertyProvider(SYSTEM_PROP_ECLIPSE_BUILD_ID, providers));
-            relevantProperties.put(SYSTEM_PROP_IDEA_SYNC_ACTIVE, systemPropertyProvider(SYSTEM_PROP_IDEA_SYNC_ACTIVE, providers));
+            Map<String, Provider<String>> ideProperties = new HashMap<>();
+            ideProperties.put(SYSTEM_PROP_IDEA_VENDOR_NAME, systemPropertyProvider(SYSTEM_PROP_IDEA_VENDOR_NAME, providers));
+            ideProperties.put(SYSTEM_PROP_IDEA_VERSION, systemPropertyProvider(SYSTEM_PROP_IDEA_VERSION, providers));
+            ideProperties.put(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE, gradlePropertyProvider(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE, providers));
+            ideProperties.put(PROJECT_PROP_ANDROID_STUDIO_VERSION, gradlePropertyProvider(PROJECT_PROP_ANDROID_STUDIO_VERSION, providers));
+            ideProperties.put(SYSTEM_PROP_ECLIPSE_BUILD_ID, systemPropertyProvider(SYSTEM_PROP_ECLIPSE_BUILD_ID, providers));
+            ideProperties.put(SYSTEM_PROP_IDEA_SYNC_ACTIVE, systemPropertyProvider(SYSTEM_PROP_IDEA_SYNC_ACTIVE, providers));
 
             // Process data at execution time to ensure property initialization
-            buildScan.buildFinished(new CaptureIdeMetadataAction(buildScan, relevantProperties));
+            buildScan.buildFinished(new CaptureIdeMetadataAction(buildScan, ideProperties));
         }
     }
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -4,13 +4,15 @@ import com.gradle.scan.plugin.BuildResult;
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
+import org.gradle.api.file.Directory;
 import org.gradle.api.invocation.Gradle;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.util.GradleVersion;
 
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -31,6 +33,13 @@ import static com.gradle.Utils.urlEncode;
  * Adds a standard set of useful tags, links and custom values to all build scans published.
  */
 final class CustomBuildScanEnhancements {
+
+    private static final String SYSTEM_PROP_IDEA_VENDOR_NAME = "idea.vendor.name";
+    private static final String SYSTEM_PROP_IDEA_VERSION = "idea.version";
+    private static final String PROJECT_PROP_ANDROID_INVOKED_FROM_IDE = "android.injected.invoked.from.ide";
+    private static final String PROJECT_PROP_ANDROID_STUDIO_VERSION = "android.injected.studio.version";
+    private static final String SYSTEM_PROP_ECLIPSE_BUILD_ID = "eclipse.buildId";
+    private static final String SYSTEM_PROP_IDEA_SYNC_ACTIVE = "idea.sync.active";
 
     private final BuildScanExtension buildScan;
     private final ProviderFactory providers;
@@ -60,47 +69,80 @@ final class CustomBuildScanEnhancements {
 
     private void captureIde() {
         if (!CiUtils.isCi(providers)) {
-            // Wait for projects to load to ensure Gradle project properties are initialized
-            gradle.projectsEvaluated(g -> {
-                Optional<String> ideaVendorName = Utils.sysProperty("idea.vendor.name", providers);
-                Optional<String> ideaVersion = Utils.sysProperty("idea.version", providers);
-                Optional<String> invokedFromAndroidStudio = Utils.projectProperty("android.injected.invoked.from.ide", providers, gradle);
-                Optional<String> androidStudioVersion = Utils.projectProperty("android.injected.studio.version", providers, gradle);
-                Optional<String> eclipseVersion = Utils.sysProperty("eclipse.buildId", providers);
-                Optional<String> ideaSync = Utils.sysProperty("idea.sync.active", providers);
+            // Prepare relevant properties for use at execution time
+            Map<String, Provider<String>> relevantProperties = new HashMap<>();
+            relevantProperties.put(SYSTEM_PROP_IDEA_VENDOR_NAME, systemPropertyProvider(SYSTEM_PROP_IDEA_VENDOR_NAME, providers));
+            relevantProperties.put(SYSTEM_PROP_IDEA_VERSION, systemPropertyProvider(SYSTEM_PROP_IDEA_VERSION, providers));
+            relevantProperties.put(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE, gradlePropertyProvider(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE, providers));
+            relevantProperties.put(PROJECT_PROP_ANDROID_STUDIO_VERSION, gradlePropertyProvider(PROJECT_PROP_ANDROID_STUDIO_VERSION, providers));
+            relevantProperties.put(SYSTEM_PROP_ECLIPSE_BUILD_ID, systemPropertyProvider(SYSTEM_PROP_ECLIPSE_BUILD_ID, providers));
+            relevantProperties.put(SYSTEM_PROP_IDEA_SYNC_ACTIVE, systemPropertyProvider(SYSTEM_PROP_IDEA_SYNC_ACTIVE, providers));
 
-                if (ideaVendorName.isPresent()) {
-                    String ideaVendorNameValue = ideaVendorName.get();
-                    if (ideaVendorNameValue.equals("Google")) {
-                        // using androidStudioVersion instead of ideaVersion for compatibility reasons, those can be different (e.g. 2020.3.1 Patch 3 instead of 2020.3)
-                        tagIde("Android Studio", androidStudioVersion.orElse(""));
-                    } else if (ideaVendorNameValue.equals("JetBrains")) {
-                        tagIde("IntelliJ IDEA", ideaVersion.orElse(""));
-                    }
-                } else if (invokedFromAndroidStudio.isPresent()) {
-                    // this case should be handled by the ideaVendorName condition but keeping it for compatibility reason (ideaVendorName started with 2020.1)
-                    tagIde("Android Studio", androidStudioVersion.orElse(""));
-                } else if (ideaVersion.isPresent()) {
-                    // this case should be handled by the ideaVendorName condition but keeping it for compatibility reason (ideaVendorName started with 2020.1)
-                    tagIde("IntelliJ IDEA", ideaVersion.get());
-                } else if (eclipseVersion.isPresent()) {
-                    tagIde("Eclipse", eclipseVersion.get());
-                } else {
-                    buildScan.tag("Cmd Line");
-                }
-
-                if (ideaSync.isPresent()) {
-                    buildScan.tag("IDE sync");
-                }
-            });
+            // Process data at execution time to ensure property initialization
+            buildScan.buildFinished(new CaptureIdeMetadataAction(buildScan, relevantProperties));
         }
     }
 
-    private void tagIde(String ideLabel, String version) {
-        buildScan.tag(ideLabel);
-        if (!version.isEmpty()) {
-            buildScan.value(ideLabel + " version", version);
+    private Provider<String> systemPropertyProvider(String name, ProviderFactory providers) {
+        if(Utils.isGradle61OrNewer()) {
+            return providers.systemProperty(name);
+        } else {
+            return providers.provider(() -> System.getProperty(name));
         }
+    }
+
+    private Provider<String> gradlePropertyProvider(String name, ProviderFactory providers) {
+        if(Utils.isGradle62OrNewer()) {
+            return providers.gradleProperty(name);
+        } else {
+            return providers.provider(() -> (String) gradle.getRootProject().findProperty(name));
+        }
+    }
+
+    private static final class CaptureIdeMetadataAction implements Action<BuildResult> {
+
+        private final BuildScanExtension buildScan;
+        private final Map<String, Provider<String>> props;
+
+        private CaptureIdeMetadataAction(BuildScanExtension buildScan, Map<String, Provider<String>> props) {
+            this.buildScan = buildScan;
+            this.props = props;
+        }
+
+        @Override
+        public void execute(BuildResult buildResult) {
+            if (props.get(SYSTEM_PROP_IDEA_VENDOR_NAME).isPresent()) {
+                String ideaVendorNameValue = props.get(SYSTEM_PROP_IDEA_VENDOR_NAME).get();
+                if (ideaVendorNameValue.equals("Google")) {
+                    // using androidStudioVersion instead of ideaVersion for compatibility reasons, those can be different (e.g. 2020.3.1 Patch 3 instead of 2020.3)
+                    tagIde("Android Studio", props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION).getOrElse(""));
+                } else if (ideaVendorNameValue.equals("JetBrains")) {
+                    tagIde("IntelliJ IDEA", props.get(SYSTEM_PROP_IDEA_VERSION).getOrElse(""));
+                }
+            } else if (props.get(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE).isPresent()) {
+                // this case should be handled by the ideaVendorName condition but keeping it for compatibility reason (ideaVendorName started with 2020.1)
+                tagIde("Android Studio", props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION).getOrElse(""));
+            } else if (props.get(SYSTEM_PROP_IDEA_VERSION).isPresent()) {
+                // this case should be handled by the ideaVendorName condition but keeping it for compatibility reason (ideaVendorName started with 2020.1)
+                tagIde("IntelliJ IDEA", props.get(SYSTEM_PROP_IDEA_VERSION).get());
+            } else if (props.get(SYSTEM_PROP_ECLIPSE_BUILD_ID).isPresent()) {
+                tagIde("Eclipse", props.get(SYSTEM_PROP_ECLIPSE_BUILD_ID).get());
+            } else {
+                buildScan.tag("Cmd Line");
+            }
+
+            if (props.get(SYSTEM_PROP_IDEA_SYNC_ACTIVE).isPresent()) {
+                buildScan.tag("IDE sync");
+            }
+        }
+
+        private void tagIde(String ideLabel, String version) {
+            buildScan.tag(ideLabel);
+            if (!version.isEmpty()) {
+                buildScan.value(ideLabel + " version", version);
+            }
+        }
+
     }
 
     private void captureCiOrLocal() {
@@ -108,162 +150,199 @@ final class CustomBuildScanEnhancements {
     }
 
     private void captureCiMetadata() {
-        if (CiUtils.isJenkins(providers) || CiUtils.isHudson(providers)) {
-            Optional<String> buildUrl = Utils.envVariable("BUILD_URL", providers);
-            Optional<String> buildNumber = Utils.envVariable("BUILD_NUMBER", providers);
-            Optional<String> nodeName = Utils.envVariable("NODE_NAME", providers);
-            Optional<String> jobName = Utils.envVariable("JOB_NAME", providers);
-            Optional<String> stageName = Utils.envVariable("STAGE_NAME", providers);
+        if (CiUtils.isCi(providers)) {
+            // Prepare project directory for use at execution time
+            Provider<Directory> projectDirectory = providers.provider(() -> gradle.getRootProject().getLayout().getProjectDirectory());
 
-            buildUrl.ifPresent(url ->
-                buildScan.link(CiUtils.isJenkins(providers) ? "Jenkins build" : "Hudson build", url));
-            buildNumber.ifPresent(value ->
-                buildScan.value("CI build number", value));
-            nodeName.ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI node", value));
-            jobName.ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
-            stageName.ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
-
-            jobName.ifPresent(j -> buildNumber.ifPresent(b -> {
-                Map<String, String> params = new LinkedHashMap<>();
-                params.put("CI job", j);
-                params.put("CI build number", b);
-                customValueSearchLinker.registerLink("CI pipeline", params);
-            }));
-        }
-
-        if (CiUtils.isTeamCity(providers)) {
-            // Wait for projects to load to ensure Gradle project properties are initialized
-            gradle.projectsEvaluated(g -> {
-                Optional<String> teamCityConfigFile = Utils.projectProperty("teamcity.configuration.properties.file", providers, gradle);
-                Optional<String> buildId = Utils.projectProperty("teamcity.build.id", providers, gradle);
-                if (teamCityConfigFile.isPresent() && buildId.isPresent()) {
-                    Properties properties = Utils.readPropertiesFile(teamCityConfigFile.get(), providers, gradle);
-                    String teamCityServerUrl = properties.getProperty("teamcity.serverUrl");
-                    if (teamCityServerUrl != null) {
-                        String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildId=" + urlEncode(buildId.get());
-                        buildScan.link("TeamCity build", buildUrl);
-                    }
-                }
-                Utils.projectProperty("build.number", providers, gradle).ifPresent(value ->
-                    buildScan.value("CI build number", value));
-                Utils.projectProperty("teamcity.buildType.id", providers, gradle).ifPresent(value ->
-                    customValueSearchLinker.addCustomValueAndSearchLink("CI build config", value));
-                Utils.projectProperty("agent.name", providers, gradle).ifPresent(value ->
-                    customValueSearchLinker.addCustomValueAndSearchLink("CI agent", value));
-            });
-        }
-
-        if (CiUtils.isCircleCI(providers)) {
-            Utils.envVariable("CIRCLE_BUILD_URL", providers).ifPresent(url ->
-                buildScan.link("CircleCI build", url));
-            Utils.envVariable("CIRCLE_BUILD_NUM", providers).ifPresent(value ->
-                buildScan.value("CI build number", value));
-            Utils.envVariable("CIRCLE_JOB", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
-            Utils.envVariable("CIRCLE_WORKFLOW_ID", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI workflow", value));
-        }
-
-        if (CiUtils.isBamboo(providers)) {
-            Utils.envVariable("bamboo_resultsUrl", providers).ifPresent(url ->
-                buildScan.link("Bamboo build", url));
-            Utils.envVariable("bamboo_buildNumber", providers).ifPresent(value ->
-                buildScan.value("CI build number", value));
-            Utils.envVariable("bamboo_planName", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI plan", value));
-            Utils.envVariable("bamboo_buildPlanName", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI build plan", value));
-            Utils.envVariable("bamboo_agentId", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI agent", value));
-        }
-
-        if (CiUtils.isGitHubActions(providers)) {
-            Optional<String> gitHubRepository = Utils.envVariable("GITHUB_REPOSITORY", providers);
-            Optional<String> gitHubRunId = Utils.envVariable("GITHUB_RUN_ID", providers);
-            if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
-                buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
-            }
-            Utils.envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI workflow", value));
-            Utils.envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI run", value));
-        }
-
-        if (CiUtils.isGitLab(providers)) {
-            Utils.envVariable("CI_JOB_URL", providers).ifPresent(url ->
-                buildScan.link("GitLab build", url));
-            Utils.envVariable("CI_PIPELINE_URL", providers).ifPresent(url ->
-                buildScan.link("GitLab pipeline", url));
-            Utils.envVariable("CI_JOB_NAME", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
-            Utils.envVariable("CI_JOB_STAGE", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
-        }
-
-        if (CiUtils.isTravis(providers)) {
-            Utils.envVariable("TRAVIS_BUILD_WEB_URL", providers).ifPresent(url ->
-                buildScan.link("Travis build", url));
-            Utils.envVariable("TRAVIS_BUILD_NUMBER", providers).ifPresent(value ->
-                buildScan.value("CI build number", value));
-            Utils.envVariable("TRAVIS_JOB_NAME", providers).ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
-            Utils.envVariable("TRAVIS_EVENT_TYPE", providers).ifPresent(buildScan::tag);
-        }
-
-        if (CiUtils.isBitrise(providers)) {
-            Utils.envVariable("BITRISE_BUILD_URL", providers).ifPresent(url ->
-                buildScan.link("Bitrise build", url));
-            Utils.envVariable("BITRISE_BUILD_NUMBER", providers).ifPresent(value ->
-                buildScan.value("CI build number", value));
-        }
-
-        if (CiUtils.isGoCD(providers)) {
-            Optional<String> pipelineName = Utils.envVariable("GO_PIPELINE_NAME", providers);
-            Optional<String> pipelineNumber = Utils.envVariable("GO_PIPELINE_COUNTER", providers);
-            Optional<String> stageName = Utils.envVariable("GO_STAGE_NAME", providers);
-            Optional<String> stageNumber = Utils.envVariable("GO_STAGE_COUNTER", providers);
-            Optional<String> jobName = Utils.envVariable("GO_JOB_NAME", providers);
-            Optional<String> goServerUrl = Utils.envVariable("GO_SERVER_URL", providers);
-            if (Stream.of(pipelineName, pipelineNumber, stageName, stageNumber, jobName, goServerUrl).allMatch(Optional::isPresent)) {
-                //noinspection OptionalGetWithoutIsPresent
-                String buildUrl = String.format("%s/tab/build/detail/%s/%s/%s/%s/%s",
-                    goServerUrl.get(), pipelineName.get(),
-                    pipelineNumber.get(), stageName.get(), stageNumber.get(), jobName.get());
-                buildScan.link("GoCD build", buildUrl);
-            } else if (goServerUrl.isPresent()) {
-                buildScan.link("GoCD", goServerUrl.get());
-            }
-            pipelineName.ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI pipeline", value));
-            jobName.ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
-            stageName.ifPresent(value ->
-                customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
-        }
-
-        if(CiUtils.isAzurePipelines(providers)) {
-            Optional<String> azureServerUrl = Utils.envVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", providers);
-            Optional<String> azureProject = Utils.envVariable("SYSTEM_TEAMPROJECT", providers);
-            Optional<String> buildId = Utils.envVariable("BUILD_BUILDID", providers);
-            if (Stream.of(azureServerUrl, azureProject, buildId).allMatch(Optional::isPresent)) {
-                //noinspection OptionalGetWithoutIsPresent
-                String buildUrl = String.format("%s%s/_build/results?buildId=%s",
-                    azureServerUrl.get(), azureProject.get(), buildId.get());
-                buildScan.link("Azure Pipelines build", buildUrl);
-            } else if (azureServerUrl.isPresent()) {
-                buildScan.link("Azure Pipelines", azureServerUrl.get());
-            }
-
-            buildId.ifPresent(value ->
-                buildScan.value("CI build number", value));
+            // Process data at execution time not to have a CI environment variable (ie. build number) invalidates the configuration cache
+            buildScan.buildFinished(new CaptureCiMetadataAction(buildScan, providers, customValueSearchLinker, projectDirectory));
         }
     }
 
+    private static final class CaptureCiMetadataAction implements Action<BuildResult> {
+
+        private final BuildScanExtension buildScan;
+        private final ProviderFactory providers;
+        private final CustomValueSearchLinker customValueSearchLinker;
+        private final Provider<Directory> projectDirectory;
+
+        private CaptureCiMetadataAction(BuildScanExtension buildScan, ProviderFactory providers, CustomValueSearchLinker customValueSearchLinker, Provider<Directory> projectDirectory) {
+            this.buildScan = buildScan;
+            this.providers = providers;
+            this.customValueSearchLinker = customValueSearchLinker;
+            this.projectDirectory = projectDirectory;
+        }
+
+        @Override
+        public void execute(BuildResult buildResult) {
+            if (CiUtils.isJenkins(providers) || CiUtils.isHudson(providers)) {
+                Optional<String> buildUrl = Utils.envVariable("BUILD_URL", providers);
+                Optional<String> buildNumber = Utils.envVariable("BUILD_NUMBER", providers);
+                Optional<String> nodeName = Utils.envVariable("NODE_NAME", providers);
+                Optional<String> jobName = Utils.envVariable("JOB_NAME", providers);
+                Optional<String> stageName = Utils.envVariable("STAGE_NAME", providers);
+
+                buildUrl.ifPresent(url ->
+                        buildScan.link(CiUtils.isJenkins(providers) ? "Jenkins build" : "Hudson build", url));
+                buildNumber.ifPresent(value ->
+                        buildScan.value("CI build number", value));
+                nodeName.ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI node", value));
+                jobName.ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
+                stageName.ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
+
+                jobName.ifPresent(j -> buildNumber.ifPresent(b -> {
+                    Map<String, String> params = new LinkedHashMap<>();
+                    params.put("CI job", j);
+                    params.put("CI build number", b);
+                    customValueSearchLinker.registerLink("CI pipeline", params);
+                }));
+            }
+
+            if(CiUtils.isTeamCity(providers)) {
+                Optional<String> teamcityBuildPropertiesFile = Utils.envVariable("TEAMCITY_BUILD_PROPERTIES_FILE", providers);
+                if(teamcityBuildPropertiesFile.isPresent()){
+                    Properties buildProperties = Utils.readPropertiesFile(teamcityBuildPropertiesFile.get(), providers, projectDirectory.get());
+
+                    String teamcityConfigFile = buildProperties.getProperty("teamcity.configuration.properties.file");
+                    if(Utils.isNotEmpty(teamcityConfigFile)) {
+                        Properties configProperties = Utils.readPropertiesFile(teamcityConfigFile, providers, projectDirectory.get());
+
+                        String teamCityServerUrl = configProperties.getProperty("teamcity.serverUrl");
+                        String teamCityBuildId = buildProperties.getProperty("teamcity.build.id");
+                        if (Utils.isNotEmpty(teamCityServerUrl) && Utils.isNotEmpty(teamCityBuildId)) {
+                            String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildId=" + urlEncode(teamCityBuildId);
+                            buildScan.link("TeamCity build", buildUrl);
+                        }
+                    }
+
+                    String teamCityBuildNumber = buildProperties.getProperty("build.number");
+                    if (Utils.isNotEmpty(teamCityBuildNumber)) {
+                        buildScan.value("CI build number", teamCityBuildNumber);
+                    }
+                    String teamCityBuildTypeId = buildProperties.getProperty("teamcity.buildType.id");
+                    if (Utils.isNotEmpty(teamCityBuildTypeId)) {
+                        buildScan.value("CI build config", teamCityBuildTypeId);
+                    }
+                    String teamCityAgentName = buildProperties.getProperty("agent.name");
+                    if (Utils.isNotEmpty(teamCityAgentName)) {
+                        buildScan.value("CI agent", teamCityAgentName);
+                    }
+                }
+            }
+
+            if (CiUtils.isCircleCI(providers)) {
+                Utils.envVariable("CIRCLE_BUILD_URL", providers).ifPresent(url ->
+                        buildScan.link("CircleCI build", url));
+                Utils.envVariable("CIRCLE_BUILD_NUM", providers).ifPresent(value ->
+                        buildScan.value("CI build number", value));
+                Utils.envVariable("CIRCLE_JOB", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
+                Utils.envVariable("CIRCLE_WORKFLOW_ID", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI workflow", value));
+            }
+
+            if (CiUtils.isBamboo(providers)) {
+                Utils.envVariable("bamboo_resultsUrl", providers).ifPresent(url ->
+                        buildScan.link("Bamboo build", url));
+                Utils.envVariable("bamboo_buildNumber", providers).ifPresent(value ->
+                        buildScan.value("CI build number", value));
+                Utils.envVariable("bamboo_planName", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI plan", value));
+                Utils.envVariable("bamboo_buildPlanName", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI build plan", value));
+                Utils.envVariable("bamboo_agentId", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI agent", value));
+            }
+
+            if (CiUtils.isGitHubActions(providers)) {
+                Optional<String> gitHubRepository = Utils.envVariable("GITHUB_REPOSITORY", providers);
+                Optional<String> gitHubRunId = Utils.envVariable("GITHUB_RUN_ID", providers);
+                if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
+                    buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                }
+                Utils.envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI workflow", value));
+                Utils.envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI run", value));
+            }
+
+            if (CiUtils.isGitLab(providers)) {
+                Utils.envVariable("CI_JOB_URL", providers).ifPresent(url ->
+                        buildScan.link("GitLab build", url));
+                Utils.envVariable("CI_PIPELINE_URL", providers).ifPresent(url ->
+                        buildScan.link("GitLab pipeline", url));
+                Utils.envVariable("CI_JOB_NAME", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
+                Utils.envVariable("CI_JOB_STAGE", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
+            }
+
+            if (CiUtils.isTravis(providers)) {
+                Utils.envVariable("TRAVIS_BUILD_WEB_URL", providers).ifPresent(url ->
+                        buildScan.link("Travis build", url));
+                Utils.envVariable("TRAVIS_BUILD_NUMBER", providers).ifPresent(value ->
+                        buildScan.value("CI build number", value));
+                Utils.envVariable("TRAVIS_JOB_NAME", providers).ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
+                Utils.envVariable("TRAVIS_EVENT_TYPE", providers).ifPresent(buildScan::tag);
+            }
+
+            if (CiUtils.isBitrise(providers)) {
+                Utils.envVariable("BITRISE_BUILD_URL", providers).ifPresent(url ->
+                        buildScan.link("Bitrise build", url));
+                Utils.envVariable("BITRISE_BUILD_NUMBER", providers).ifPresent(value ->
+                        buildScan.value("CI build number", value));
+            }
+
+            if (CiUtils.isGoCD(providers)) {
+                Optional<String> pipelineName = Utils.envVariable("GO_PIPELINE_NAME", providers);
+                Optional<String> pipelineNumber = Utils.envVariable("GO_PIPELINE_COUNTER", providers);
+                Optional<String> stageName = Utils.envVariable("GO_STAGE_NAME", providers);
+                Optional<String> stageNumber = Utils.envVariable("GO_STAGE_COUNTER", providers);
+                Optional<String> jobName = Utils.envVariable("GO_JOB_NAME", providers);
+                Optional<String> goServerUrl = Utils.envVariable("GO_SERVER_URL", providers);
+                if (Stream.of(pipelineName, pipelineNumber, stageName, stageNumber, jobName, goServerUrl).allMatch(Optional::isPresent)) {
+                    //noinspection OptionalGetWithoutIsPresent
+                    String buildUrl = String.format("%s/tab/build/detail/%s/%s/%s/%s/%s",
+                            goServerUrl.get(), pipelineName.get(),
+                            pipelineNumber.get(), stageName.get(), stageNumber.get(), jobName.get());
+                    buildScan.link("GoCD build", buildUrl);
+                } else if (goServerUrl.isPresent()) {
+                    buildScan.link("GoCD", goServerUrl.get());
+                }
+                pipelineName.ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI pipeline", value));
+                jobName.ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI job", value));
+                stageName.ifPresent(value ->
+                        customValueSearchLinker.addCustomValueAndSearchLink("CI stage", value));
+            }
+
+            if(CiUtils.isAzurePipelines(providers)) {
+                Optional<String> azureServerUrl = Utils.envVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", providers);
+                Optional<String> azureProject = Utils.envVariable("SYSTEM_TEAMPROJECT", providers);
+                Optional<String> buildId = Utils.envVariable("BUILD_BUILDID", providers);
+                if (Stream.of(azureServerUrl, azureProject, buildId).allMatch(Optional::isPresent)) {
+                    //noinspection OptionalGetWithoutIsPresent
+                    String buildUrl = String.format("%s%s/_build/results?buildId=%s",
+                            azureServerUrl.get(), azureProject.get(), buildId.get());
+                    buildScan.link("Azure Pipelines build", buildUrl);
+                } else if (azureServerUrl.isPresent()) {
+                    buildScan.link("Azure Pipelines", azureServerUrl.get());
+                }
+
+                buildId.ifPresent(value ->
+                        buildScan.value("CI build number", value));
+            }
+        }
+
+    }
 
     private void captureGitMetadata() {
+        // Run expensive computation in background
         buildScan.background(new CaptureGitMetadataAction(providers, customValueSearchLinker));
     }
 
@@ -424,7 +503,7 @@ final class CustomBuildScanEnhancements {
     private void captureTestParallelization() {
         gradle.afterProject(p -> {
             TaskCollection<Test> tests = p.getTasks().withType(Test.class);
-            if (isGradle5OrNewer()) {
+            if (Utils.isGradle5OrNewer()) {
                 tests.configureEach(captureMaxParallelForks(buildScan));
             } else {
                 tests.all(captureMaxParallelForks(buildScan));
@@ -443,10 +522,6 @@ final class CustomBuildScanEnhancements {
                 }
             });
         };
-    }
-
-    private static boolean isGradle5OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0;
     }
 
 }

--- a/src/main/java/com/gradle/ProxyFactory.java
+++ b/src/main/java/com/gradle/ProxyFactory.java
@@ -5,7 +5,9 @@ import org.gradle.api.Action;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 final class ProxyFactory {
 

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -1,7 +1,7 @@
 package com.gradle;
 
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.util.GradleVersion;
@@ -26,16 +26,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 final class Utils {
-
-    static Optional<String> projectProperty(String name, ProviderFactory providers, Gradle gradle) {
-        if (isGradle65OrNewer() && !isGradle74OrNewer()) {
-            // invalidate configuration cache if different Gradle property value is set on the cmd line,
-            // but in any case access Gradle property directly since project properties set in a build script or
-            // init script are not fetched by ProviderFactory.gradleProperty
-            providers.gradleProperty(name).forUseAtConfigurationTime();
-        }
-        return Optional.ofNullable((String) gradle.getRootProject().findProperty(name));
-    }
 
     static Optional<String> sysPropertyOrEnvVariable(String sysPropertyName, String envVarName, ProviderFactory providers) {
         Optional<String> sysProperty = sysProperty(sysPropertyName, providers);
@@ -136,8 +126,8 @@ final class Utils {
         }
     }
 
-    static Properties readPropertiesFile(String name, ProviderFactory providers, Gradle gradle) {
-        try (InputStream input = readFile(name, providers, gradle)) {
+    static Properties readPropertiesFile(String name, ProviderFactory providers, Directory projectDirectory) {
+        try (InputStream input = readFile(name, providers, projectDirectory)) {
             Properties properties = new Properties();
             properties.load(input);
             return properties;
@@ -146,13 +136,10 @@ final class Utils {
         }
     }
 
-    static InputStream readFile(String name, ProviderFactory providers, Gradle gradle) throws FileNotFoundException {
+    static InputStream readFile(String name, ProviderFactory providers, Directory projectDirectory) throws FileNotFoundException {
         if (isGradle65OrNewer()) {
-            RegularFile file = gradle.getRootProject().getLayout().getProjectDirectory().file(name);
+            RegularFile file = projectDirectory.file(name);
             Provider<byte[]> fileContent = providers.fileContents(file).getAsBytes();
-            if (!isGradle74OrNewer()) {
-                fileContent = fileContent.forUseAtConfigurationTime();
-            }
             return new ByteArrayInputStream(fileContent.getOrElse(new byte[0]));
         }
         return new FileInputStream(name);
@@ -212,12 +199,36 @@ final class Utils {
         return ('x' + str).trim().substring(1);
     }
 
-    private static boolean isGradle65OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0;
+    static boolean isGradle4OrNewer() {
+        return isGradleNewerThan("4.0");
     }
 
-    private static boolean isGradle74OrNewer() {
-        return GradleVersion.current().compareTo(GradleVersion.version("7.4")) >= 0;
+    static boolean isGradle5OrNewer() {
+        return isGradleNewerThan("5.0");
+    }
+
+    static boolean isGradle6OrNewer() {
+        return isGradleNewerThan("6.0");
+    }
+
+    static boolean isGradle61OrNewer() {
+        return isGradleNewerThan("6.1");
+    }
+
+    static boolean isGradle62OrNewer() {
+        return isGradleNewerThan("6.2");
+    }
+
+    static boolean isGradle65OrNewer() {
+        return isGradleNewerThan("6.5");
+    }
+
+    static boolean isGradle74OrNewer() {
+        return isGradleNewerThan("7.4");
+    }
+
+    private static boolean isGradleNewerThan(String version) {
+        return GradleVersion.current().compareTo(GradleVersion.version(version)) >= 0;
     }
 
     private Utils() {

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -203,6 +203,10 @@ final class Utils {
         return isGradleNewerThan("4.0");
     }
 
+    public static boolean isGradle43rNewer() {
+        return isGradleNewerThan("4.3");
+    }
+
     static boolean isGradle5OrNewer() {
         return isGradleNewerThan("5.0");
     }


### PR DESCRIPTION
The PR aims to capture CI and IDE metadata at execution time (in a `buildFinished` block), therefore preventing configuration cache invalidation if a property changes (ie. `CI build number`)

Teamcity data are now fetched from a teamcity generated build file as project properties set in an init file can't easily be read at execution time through a [Provider](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/ProviderFactory.html#gradleProperty-java.lang.String-) due to https://github.com/gradle/gradle/issues/23572.

The `projectEvaluated` callback has been replaced by `Providers` used at execution time in order to fix configuration cache restore scenarii.

Note that Teamcity is not yet compatible with configuration cache due to [this](https://youtrack.jetbrains.com/issue/TW-71916)

fixes https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/80

This PR was tested with 
- Gradle 6.0, 7.2, 7.6
- w/o configuration cache
- Jenkins 2.332.3
- Teamcity 2022.10.1 (build 116934)
- Android Studio 2021.3.1 Patch 1

Signed-off-by: Jerome Prinet [jprinet@gradle.com](mailto:jprinet@gradle.com)