### PR TITLE
User can configure BT and GE build cache connector with the same sys prop `gradle.cache.remote.url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ to modify the build scripts. For example, to disable the local build cache when 
 | buildCache.remote.setEnabled              | gradle.cache.remote.enabled              | GRADLE_CACHE_REMOTE_ENABLED              |
 | buildCache.remote.setPush                 | gradle.cache.remote.push                 | GRADLE_CACHE_REMOTE_PUSH                 |
 | buildCache.remote.setAllowUntrustedServer | gradle.cache.remote.allowUntrustedServer | GRADLE_CACHE_REMOTE_ALLOWUNTRUSTEDSERVER |
-| buildCache.remote.setServer               | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
+| buildCache.remote.setServer/setPath       | gradle.cache.remote.url                  | GRADLE_CACHE_REMOTE_URL                  |
 | buildCache.remote.setPath                 | gradle.cache.remote.path                 | GRADLE_CACHE_REMOTE_PATH                 |
 | buildCache.remote.setPath                 | gradle.cache.remote.shard                | GRADLE_CACHE_REMOTE_SHARD                |
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -222,7 +222,7 @@ final class CustomBuildScanEnhancements {
 
                             String teamCityServerUrl = configProperties.getProperty("teamcity.serverUrl");
                             if (isNotEmpty(teamCityServerUrl)) {
-                                String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildId=" + urlEncode(teamCityBuildId);
+                                String buildUrl = appendIfMissing(teamCityServerUrl, '/') + "viewLog.html?buildId=" + urlEncode(teamCityBuildId);
                                 buildScan.link("TeamCity build", buildUrl);
                             }
                         }
@@ -488,7 +488,7 @@ final class CustomBuildScanEnhancements {
         String searchParams = "search.names=" + urlEncode(name) + "&search.values=" + urlEncode(value);
         String server = getServer(buildScan);
         if (server != null) {
-            String url = appendIfMissing(server, "/") + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}");
+            String url = appendIfMissing(server, '/') + "scans?" + searchParams + "#selection.buildScanB=" + urlEncode("{SCAN_ID}");
             buildScan.link(linkLabel + " build scans", url);
         }
     }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -13,7 +13,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 import static com.gradle.Utils.appendIfMissing;
-import static com.gradle.Utils.prependIfMissing;
+import static com.gradle.Utils.prependAndAppendIfMissing;
 import static com.gradle.Utils.stripPrefix;
 
 /**
@@ -106,7 +106,7 @@ final class Overrides {
 
     private static URI replacePath(URI uri, String path) {
         try {
-            String finalPath = appendIfMissing(prependIfMissing("/", path), "/");
+            String finalPath = prependAndAppendIfMissing(path, "/");
             return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), finalPath, uri.getQuery(), uri.getFragment());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Cannot construct URI: " + uri, e);
@@ -115,7 +115,7 @@ final class Overrides {
 
     private static URI appendPath(URI uri, String path) {
         try {
-            String currentPath = appendIfMissing(prependIfMissing("/", uri.getPath()), "/");
+            String currentPath = prependAndAppendIfMissing(uri.getPath(), "/");
             String additionalPath = appendIfMissing(stripPrefix("/", path), "/");
             String finalPath = currentPath + additionalPath;
             return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), finalPath, uri.getQuery(), uri.getFragment());
@@ -139,7 +139,7 @@ final class Overrides {
     }
 
     private static String joinPaths(String basePath, String path) {
-        String currentPath = appendIfMissing(prependIfMissing("/", basePath), "/");
+        String currentPath = prependAndAppendIfMissing(basePath, "/");
         String additionalPath = stripPrefix("/", path); // do not slashify the path when using the GE cache connector
         return currentPath + additionalPath;
     }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -78,7 +78,7 @@ final class Overrides {
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::serverOnly).ifPresent(remote::setServer);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(remote::setPath);
-                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setPath(concatenatePaths(remote.getPath(), shard)));
+                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> concatenatePaths(remote.getPath(), shard)).ifPresent(remote::setPath);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_PUSH, providers).ifPresent(remote::setPush);

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -128,7 +128,7 @@ final class Overrides {
     }
 
     private static String serverOnly(String urlString) {
-        URL url = toUrl(urlString);
+        URL url = Utils.toUrl(urlString);
         try {
             return new URL(url.getProtocol(), url.getHost(), url.getPort(), "").toExternalForm();
         } catch (MalformedURLException e) {
@@ -137,32 +137,8 @@ final class Overrides {
     }
 
     private static String pathOnly(String urlString) {
-        URL url = toUrl(urlString);
+        URL url = Utils.toUrl(urlString);
         return url.getPath();
-    }
-
-    private static URL toUrl(String urlString) {
-        try {
-            return new URL(urlString);
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Cannot parse URL: " + urlString, e);
-        }
-    }
-
-    public static void main(String[] args) throws URISyntaxException {
-        URI uri = replacePath(new URI("https://eti:stu@ge.gradle.org/cache?foo=bar#abc"), "caches");
-        System.out.println("replacePath = " + uri);
-
-        URI caches = appendPath(new URI("https://eti:stu@ge.gradle.org/cache?foo=bar#abc"), "caches");
-        System.out.println("appendPath = " + caches);
-
-        String s = serverOnly("https://eti:stu@ge.gradle.org/cache/foo=bar#abc");
-        System.out.println("serverOnly = " + s);
-
-        String path = pathOnly("https://ge.gradle.org/cache/?foo=bar#er");
-        System.out.println("pathOnly = " + path);
-
-
     }
 
 }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -14,8 +14,10 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
 
+import static com.gradle.Utils.appendIfMissing;
 import static com.gradle.Utils.appendPathAndTrailingSlash;
 import static com.gradle.Utils.concatenatePaths;
+import static com.gradle.Utils.prependIfMissing;
 
 /**
  * Provide standardized Gradle Enterprise configuration. By applying the plugin, these settings will automatically be applied.
@@ -107,7 +109,8 @@ final class Overrides {
 
     private static URI replacePath(URI uri, String path) {
         try {
-            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), path, uri.getQuery(), uri.getFragment());
+            String pathWithSlashes = appendIfMissing(prependIfMissing("/", path), "/");
+            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), pathWithSlashes, uri.getQuery(), uri.getFragment());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Cannot construct URI: " + uri, e);
         }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -7,7 +7,6 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -128,17 +127,33 @@ final class Overrides {
     }
 
     private static String serverOnly(String urlString) {
-        URL url = Utils.toUrl(urlString);
+        URI uri = URI.create(urlString);
         try {
-            return new URL(url.getProtocol(), url.getHost(), url.getPort(), "").toExternalForm();
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Cannot construct URL: " + url, e);
+            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Cannot construct URI: " + uri, e);
         }
     }
 
     private static String pathOnly(String urlString) {
         URL url = Utils.toUrl(urlString);
         return url.getPath();
+    }
+
+    public static void main(String[] args) throws URISyntaxException {
+        URI uri = replacePath(new URI("https://eti:stu@ge.gradle.org/cache?foo=bar#abc"), "caches");
+        System.out.println("replacePath = " + uri);
+
+        URI caches = appendPath(new URI("https://eti:stu@ge.gradle.org/cache?foo=bar#abc"), "caches");
+        System.out.println("appendPath = " + caches);
+
+        String s = serverOnly("https://eti:stu@ge.gradle.org/cache/foo=bar#abc");
+        System.out.println("serverOnly = " + s);
+
+        String path = pathOnly("https://ge.gradle.org/cache/?foo=bar#er");
+        System.out.println("pathOnly = " + path);
+
+
     }
 
 }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -116,7 +116,7 @@ final class Overrides {
     private static URI appendPath(URI uri, String path) {
         try {
             String currentPath = prependAndAppendIfMissing(uri.getPath(), "/");
-            String additionalPath = appendIfMissing(stripPrefix("/", path), "/");
+            String additionalPath = appendIfMissing(stripPrefix(path, "/"), "/");
             String finalPath = currentPath + additionalPath;
             return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), finalPath, uri.getQuery(), uri.getFragment());
         } catch (URISyntaxException e) {
@@ -140,7 +140,7 @@ final class Overrides {
 
     private static String joinPaths(String basePath, String path) {
         String currentPath = prependAndAppendIfMissing(basePath, "/");
-        String additionalPath = stripPrefix("/", path); // do not slashify the path when using the GE cache connector
+        String additionalPath = stripPrefix(path, "/"); // do not slashify the path when using the GE cache connector
         return currentPath + additionalPath;
     }
 

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -107,8 +107,8 @@ final class Overrides {
 
     private static URI replacePath(URI uri, String path) {
         try {
-            String pathWithSlashes = appendIfMissing(prependIfMissing("/", path), "/");
-            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), pathWithSlashes, uri.getQuery(), uri.getFragment());
+            String finalPath = appendIfMissing(prependIfMissing("/", path), "/");
+            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), finalPath, uri.getQuery(), uri.getFragment());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Cannot construct URI: " + uri, e);
         }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -106,7 +106,7 @@ final class Overrides {
 
     private static URI replacePath(URI uri, String path) {
         try {
-            String finalPath = prependAndAppendIfMissing(path, "/");
+            String finalPath = prependAndAppendIfMissing(path, '/');
             return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), finalPath, uri.getQuery(), uri.getFragment());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Cannot construct URI: " + uri, e);
@@ -115,8 +115,8 @@ final class Overrides {
 
     private static URI appendPath(URI uri, String path) {
         try {
-            String currentPath = prependAndAppendIfMissing(uri.getPath(), "/");
-            String additionalPath = appendIfMissing(stripPrefix(path, "/"), "/");
+            String currentPath = prependAndAppendIfMissing(uri.getPath(), '/');
+            String additionalPath = appendIfMissing(stripPrefix(path, '/'), '/');
             String finalPath = currentPath + additionalPath;
             return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), finalPath, uri.getQuery(), uri.getFragment());
         } catch (URISyntaxException e) {
@@ -139,8 +139,8 @@ final class Overrides {
     }
 
     private static String joinPaths(String basePath, String path) {
-        String currentPath = prependAndAppendIfMissing(basePath, "/");
-        String additionalPath = stripPrefix(path, "/"); // do not slashify the path when using the GE cache connector
+        String currentPath = prependAndAppendIfMissing(basePath, '/');
+        String additionalPath = stripPrefix(path, '/'); // do not slashify the path when using the GE cache connector
         return currentPath + additionalPath;
     }
 

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -9,7 +9,6 @@ import org.gradle.caching.http.HttpBuildCache;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -136,8 +135,8 @@ final class Overrides {
     }
 
     private static String pathOnly(String urlString) {
-        URL url = Utils.toUrl(urlString);
-        return url.getPath();
+        URI uri = URI.create(urlString);
+        return uri.getPath();
     }
 
     public static void main(String[] args) throws URISyntaxException {

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -13,7 +13,6 @@ import java.time.Duration;
 import java.util.Optional;
 
 import static com.gradle.Utils.appendIfMissing;
-import static com.gradle.Utils.concatenatePaths;
 import static com.gradle.Utils.prependIfMissing;
 import static com.gradle.Utils.stripPrefix;
 
@@ -81,7 +80,7 @@ final class Overrides {
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::serverOnly).ifPresent(remote::setServer);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(remote::setPath);
-                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> concatenatePaths(remote.getPath(), shard)).ifPresent(remote::setPath);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> joinPaths(remote.getPath(), shard)).ifPresent(remote::setPath);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_PUSH, providers).ifPresent(remote::setPush);
@@ -139,20 +138,10 @@ final class Overrides {
         return uri.getPath();
     }
 
-    public static void main(String[] args) throws URISyntaxException {
-        URI uri = replacePath(new URI("https://eti:stu@ge.gradle.org/cache?foo=bar#abc"), "caches");
-        System.out.println("replacePath = " + uri);
-
-        URI caches = appendPath(new URI("https://eti:stu@ge.gradle.org/cache?foo=bar#abc"), "caches");
-        System.out.println("appendPath = " + caches);
-
-        String s = serverOnly("https://eti:stu@ge.gradle.org/cache/foo=bar#abc");
-        System.out.println("serverOnly = " + s);
-
-        String path = pathOnly("https://ge.gradle.org/cache/?foo=bar#er");
-        System.out.println("pathOnly = " + path);
-
-
+    private static String joinPaths(String basePath, String path) {
+        String currentPath = appendIfMissing(prependIfMissing("/", basePath), "/");
+        String additionalPath = stripPrefix("/", path); // do not slashify the path when using the GE cache connector
+        return currentPath + additionalPath;
     }
 
 }

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -78,11 +78,11 @@ final class Utils {
         return value != null && !value.isEmpty();
     }
 
-    static String stripPrefix(String prefix, String string) {
+    static String stripPrefix(String string, String prefix) {
         return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
     }
 
-    static String prependIfMissing(String prefix, String str) {
+    static String prependIfMissing(String str, String prefix) {
         return str.startsWith(prefix) ? str : prefix + str;
     }
 
@@ -90,8 +90,8 @@ final class Utils {
         return str.endsWith(suffix) ? str : str + suffix;
     }
 
-    static String prependAndAppendIfMissing(String path, String segment) {
-        return appendIfMissing(prependIfMissing(segment, path), segment);
+    static String prependAndAppendIfMissing(String path, String part) {
+        return appendIfMissing(prependIfMissing(path, part), part);
     }
 
     static String urlEncode(String str) {

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -15,8 +15,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -90,15 +92,6 @@ final class Utils {
         return str.endsWith(suffix) ? str : str + suffix;
     }
 
-    static URI appendPathAndTrailingSlash(URI baseUri, String path) {
-        if (isNotEmpty(path)) {
-            String normalizedBasePath = appendIfMissing(baseUri.getPath(), "/");
-            String normalizedPath = appendIfMissing(stripPrefix("/", path), "/");
-            return baseUri.resolve(normalizedBasePath).resolve(normalizedPath);
-        }
-        return baseUri;
-    }
-
     static String concatenatePaths(String basePath, String path) {
         if (isNotEmpty(basePath)) {
             if (isNotEmpty(path)) {
@@ -109,6 +102,14 @@ final class Utils {
             return basePath;
         }
         return path;
+    }
+
+    static URL toUrl(String urlString) {
+        try {
+            return new URL(urlString);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Cannot parse URL: " + urlString, e);
+        }
     }
 
     static String urlEncode(String str) {

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -82,6 +82,10 @@ final class Utils {
         return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
     }
 
+    static String prependIfMissing(String suffix, String str) {
+        return str.startsWith(suffix) ? str : suffix + str;
+    }
+
     static String appendIfMissing(String str, String suffix) {
         return str.endsWith(suffix) ? str : str + suffix;
     }

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -90,18 +90,6 @@ final class Utils {
         return str.endsWith(suffix) ? str : str + suffix;
     }
 
-    static String concatenatePaths(String basePath, String path) {
-        if (isNotEmpty(basePath)) {
-            if (isNotEmpty(path)) {
-                String normalizedBasePath = appendIfMissing(basePath, "/");
-                String normalizedPath = stripPrefix("/", path);
-                return normalizedBasePath + normalizedPath;
-            }
-            return basePath;
-        }
-        return path;
-    }
-
     static String urlEncode(String str) {
         try {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -90,6 +90,10 @@ final class Utils {
         return str.endsWith(suffix) ? str : str + suffix;
     }
 
+    static String prependAndAppendIfMissing(String path, String segment) {
+        return appendIfMissing(prependIfMissing(segment, path), segment);
+    }
+
     static String urlEncode(String str) {
         try {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -15,10 +15,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -102,14 +100,6 @@ final class Utils {
             return basePath;
         }
         return path;
-    }
-
-    static URL toUrl(String urlString) {
-        try {
-            return new URL(urlString);
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Cannot parse URL: " + urlString, e);
-        }
     }
 
     static String urlEncode(String str) {

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -82,8 +82,8 @@ final class Utils {
         return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
     }
 
-    static String prependIfMissing(String suffix, String str) {
-        return str.startsWith(suffix) ? str : suffix + str;
+    static String prependIfMissing(String prefix, String str) {
+        return str.startsWith(prefix) ? str : prefix + str;
     }
 
     static String appendIfMissing(String str, String suffix) {

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -78,19 +78,19 @@ final class Utils {
         return value != null && !value.isEmpty();
     }
 
-    static String stripPrefix(String string, String prefix) {
-        return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
+    static String stripPrefix(String string, char prefix) {
+        return string.startsWith(Character.toString(prefix)) ? string.substring(1) : string;
     }
 
-    static String prependIfMissing(String str, String prefix) {
-        return str.startsWith(prefix) ? str : prefix + str;
+    static String prependIfMissing(String str, char prefix) {
+        return str.startsWith(Character.toString(prefix)) ? str : prefix + str;
     }
 
-    static String appendIfMissing(String str, String suffix) {
-        return str.endsWith(suffix) ? str : str + suffix;
+    static String appendIfMissing(String str, char suffix) {
+        return str.endsWith(Character.toString(suffix)) ? str : str + suffix;
     }
 
-    static String prependAndAppendIfMissing(String path, String part) {
+    static String prependAndAppendIfMissing(String path, char part) {
         return appendIfMissing(prependIfMissing(path, part), part);
     }
 

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -79,19 +79,19 @@ final class Utils {
     }
 
     static String stripPrefix(String string, char prefix) {
-        return string.startsWith(Character.toString(prefix)) ? string.substring(1) : string;
+        return string.length() > 0 && string.charAt(0) == prefix ? string.substring(1) : string;
     }
 
-    static String prependIfMissing(String str, char prefix) {
-        return str.startsWith(Character.toString(prefix)) ? str : prefix + str;
+    static String prependIfMissing(String string, char prefix) {
+        return string.length() > 0 && string.charAt(0) == prefix ? string : prefix + string;
     }
 
-    static String appendIfMissing(String str, char suffix) {
-        return str.endsWith(Character.toString(suffix)) ? str : str + suffix;
+    static String appendIfMissing(String string, char suffix) {
+        return string.length() > 0 && string.charAt(string.length() - 1) == suffix ? string : string + suffix;
     }
 
-    static String prependAndAppendIfMissing(String path, char part) {
-        return appendIfMissing(prependIfMissing(path, part), part);
+    static String prependAndAppendIfMissing(String string, char part) {
+        return appendIfMissing(prependIfMissing(string, part), part);
     }
 
     static String urlEncode(String str) {


### PR DESCRIPTION
- Using the GE build cache connector, the remote build cache URL provided via `gradle.cache.remote.url` is split up and the _server_ and _path_ parts set individually on the GE connector API
- The behavior of configuring the BT and the GE connector is now more similar in terms replacing/appending a path provided via `gradle.cache.remote.path`