### PR TITLE
Remote preceding and trailing slashes when deriving paths from overridden URLs

### DIFF
--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -80,7 +80,7 @@ final class Overrides {
         } else if (buildCache.getRemote() instanceof GradleEnterpriseBuildCache) {
             buildCache.remote(GradleEnterpriseBuildCache.class, remote -> {
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::serverOnly).ifPresent(remote::setServer);
-                sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).ifPresent(remote::setPath);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).filter(path -> !path.isEmpty()).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> joinPaths(remote.getPath(), shard)).ifPresent(remote::setPath);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -138,7 +138,7 @@ final class Overrides {
 
     private static String pathOnly(String urlString) {
         URI uri = URI.create(urlString);
-        return uri.getPath();
+        return uri.getPath().replaceAll("^/|/$", "");
     }
 
     private static String joinPaths(String basePath, String path) {


### PR DESCRIPTION
The last set of changes to the URL override functionality introduced two behaviors:

1. Declaring a URL override with no path (such as https://ge.solutions-team.gradle.com) results in issues properly finding the build cache.
1. Declaring a URL with a path (such as https://ge.solutions-team.gradle.com/cache/) results in display of the preceding and trailing slashes (without an affect on functionality).

This change strips preceding and trailing `/` characters from the path as returned by `Uri.getPath`, then does not call into `setPath` if the resulting path is blank. This prevents us from inadvertently setting the path to `/` in behavior 1, and creates consistency in the displayed path in the build scan from behavior 2.

I've provided the below before/after scans to help make sense of the issues before this change and the result of the fixes.

## Before/After behavior of setting -Dgradle.cache.remote.url

### `https://ge.solutions-team.gradle.com`

Before: [Remote cache issues](https://ge.solutions-team.gradle.com/s/72kdi3kt46ohe/console-log?page=1#L14) / [No Path](https://ge.solutions-team.gradle.com/s/72kdi3kt46ohe/console-log?page=1#L14)
After: [No Remote cache issues](https://ge.solutions-team.gradle.com/s/cydd3bglqb32o/console-log?anchor=35&page=1) / [Path == cache](https://ge.solutions-team.gradle.com/s/cydd3bglqb32o/performance/build-cache#remote-cache-build-cache-path)

### `https://ge.solutions-team.gradle.com/`

Before: [Remote cache issues](https://ge.solutions-team.gradle.com/s/yvwyvhitjxjh2/console-log?page=1#L14) / [Path == /](https://ge.solutions-team.gradle.com/s/yvwyvhitjxjh2/performance/build-cache#remote-cache-build-cache-path)
After: [No Remote cache issues](https://ge.solutions-team.gradle.com/s/xspmn4oddbezu/console-log?anchor=35&page=1) / [Path == cache](https://ge.solutions-team.gradle.com/s/xspmn4oddbezu/performance/build-cache#remote-cache-build-cache-path)

### `https://ge.solutions-team.gradle.com/cache`

Before: [Path == /cache](https://ge.solutions-team.gradle.com/s/xp2mkqgtzwbso/performance/build-cache#remote-cache-build-cache-path)
After: [Path == cache](https://ge.solutions-team.gradle.com/s/xspmn4oddbezu/performance/build-cache#remote-cache-build-cache-path)

### `https://ge.solutions-team.gradle.com/cache/`

Before: [Path == /cache/](https://ge.solutions-team.gradle.com/s/xp2mkqgtzwbso/performance/build-cache#remote-cache-build-cache-path)
After: [Path == cache](https://ge.solutions-team.gradle.com/s/xspmn4oddbezu/performance/build-cache#remote-cache-build-cache-path)