### PR TITLE
Fixes to issues in URL Overrides for the GradleEnterpriseBuildCacheConnector

### DIFF
--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -80,7 +80,7 @@ final class Overrides {
         } else if (buildCache.getRemote() instanceof GradleEnterpriseBuildCache) {
             buildCache.remote(GradleEnterpriseBuildCache.class, remote -> {
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::serverOnly).ifPresent(remote::setServer);
-                sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).ifPresent(remote::setPath);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).filter(Overrides::isNonEmptyPath).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> joinPaths(remote.getPath(), shard)).ifPresent(remote::setPath);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
@@ -145,6 +145,10 @@ final class Overrides {
         String currentPath = prependAndAppendIfMissing(basePath, '/');
         String additionalPath = stripPrefix(path, '/'); // do not slashify the path when using the GE cache connector
         return currentPath + additionalPath;
+    }
+
+    private static boolean isNonEmptyPath(String path) {
+        return !path.isEmpty() && !path.equals("/");
     }
 
 }

--- a/src/main/java/com/gradle/Overrides.java
+++ b/src/main/java/com/gradle/Overrides.java
@@ -82,7 +82,7 @@ final class Overrides {
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::serverOnly).ifPresent(remote::setServer);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_URL, providers).map(Overrides::pathOnly).filter(Overrides::isNonEmptyPath).ifPresent(remote::setPath);
                 sysPropertyOrEnvVariable(REMOTE_CACHE_PATH, providers).ifPresent(remote::setPath);
-                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> joinPaths(remote.getPath(), shard)).ifPresent(remote::setPath);
+                sysPropertyOrEnvVariable(REMOTE_CACHE_SHARD, providers).map(shard -> joinPaths(getPath(remote), shard)).ifPresent(remote::setPath);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ALLOW_INSECURE_PROTOCOL, providers).ifPresent(remote::setAllowInsecureProtocol);
                 booleanSysPropertyOrEnvVariable(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
@@ -105,6 +105,10 @@ final class Overrides {
 
     private static String toEnvVarName(String sysPropertyName) {
         return sysPropertyName.toUpperCase().replace('.', '_');
+    }
+
+    private static String getPath(GradleEnterpriseBuildCache remote) {
+        return Optional.ofNullable(remote.getPath()).orElse("cache");
     }
 
     private static URI replacePath(URI uri, String path) {


### PR DESCRIPTION
With the latest set of changes, two scenarios fail:

- Defining a URL without a path component
- Defining a URL without a path component + a shard

With the latest set of changes, defining a URL override for the GradleEnterpriseBuildCacheConnecter without a path fails to properly connect to the build cache. For example, a build that specifies `-Dgradle.cache.remote.url=https://ge.solutions-team.gradle.com` will set the path as an empty string and result in errors like these: https://ge.solutions-team.gradle.com/s/5rtouxcb2nwdk/console-log?page=1#L14

This PR fixes this by avoiding a call to setPath if the derived path is essentially empty (i.e. '/' or an empty string).

Once that is fixed, defining a URL override without a path and a shard together throws a NullPointerException. This is address by assuming that the path is "cache" when `getPath` returns null.