### PR TITLE
Support build scan links to alternate GitHub URLs

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-[FIX] Generating incorrect "GitHub Actions Build" and "GitHub/GitLab Source" links to repositories not hosted at github.com or gitlab.com
+[FIX] Generates incorrect "GitHub Actions Build" and "GitHub/GitLab Source" links to repositories not hosted at github.com or gitlab.com

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+[FIX] Support build scan links to alternate GitHub URLs (such as GitHub Enterprise servers)

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-[FIX] Support build scan links to alternate GitHub URLs (such as GitHub Enterprise servers)
+[FIX] Generating incorrect "GitHub Actions Build" and "GitHub/GitLab Source" links to repositories not hosted at github.com or gitlab.com

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -440,16 +440,24 @@ final class CustomBuildScanEnhancements {
 
         private Optional<URI> toWebRepoUri(String gitRepoUri) {
             Matcher matcher = Pattern.compile("^(?:https://|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$").matcher(gitRepoUri);
-            if(!matcher.matches()) {
+            if (matcher.matches()) {
+                String scheme = "https";
+                String host = matcher.group(1);
+                String path = matcher.group(2).startsWith("/") ? matcher.group(2) : "/" + matcher.group(2);
+                return toUri(scheme, host, path);
+            } else {
                 return Optional.empty();
             }
+        }
+
+        private Optional<URI> toUri(String scheme, String host, String path) {
             try {
-                String path = matcher.group(2).startsWith("/") ? matcher.group(2) : "/" + matcher.group(2);
-                return Optional.of(new URI("https", matcher.group(1), path, null));
+                return Optional.of(new URI(scheme, host, path, null));
             } catch (URISyntaxException e) {
                 return Optional.empty();
             }
         }
+
     }
 
     private void captureTestParallelization() {
@@ -530,4 +538,5 @@ final class CustomBuildScanEnhancements {
             return providers.provider(() -> (String) gradle.getRootProject().findProperty(name));
         }
     }
+
 }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -397,19 +397,15 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
-                if (gitRepo.contains("github.com/") || gitRepo.contains("github.com:")) {
-                    Matcher matcher = Pattern.compile("(.*)github\\.com[/|:](.*)").matcher(gitRepo);
-                    if (matcher.matches()) {
-                        String rawRepoPath = matcher.group(2);
-                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                        buildScan.link("Github source", "https://github.com/" + repoPath + "/tree/" + gitCommitId);
-                    }
-                } else if (gitRepo.contains("gitlab.com/") || gitRepo.contains("gitlab.com:")) {
-                    Matcher matcher = Pattern.compile("(.*)gitlab\\.com[/|:](.*)").matcher(gitRepo);
-                    if (matcher.matches()) {
-                        String rawRepoPath = matcher.group(2);
-                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                        buildScan.link("GitLab Source", "https://gitlab.com/" + repoPath + "/-/commit/" + gitCommitId);
+                Matcher matcher = Pattern.compile("(https://|git@)(.+?)[:|/](.*)").matcher(gitRepo);
+                if (matcher.matches()) {
+                    String repoUrl = "https://" + matcher.group(2) + "/";
+                    String rawRepoPath = matcher.group(3);
+                    String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
+                    if (gitRepo.contains("github")) {
+                        buildScan.link("Github source", repoUrl + repoPath + "/tree/" + gitCommitId);
+                    } else if (gitRepo.contains("gitlab")) {
+                        buildScan.link("GitLab Source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
                     }
                 }
             }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -438,7 +438,7 @@ final class CustomBuildScanEnhancements {
 
         private Optional<URI> toWebRepoUri(String gitRepoUri) {
             try {
-                URI tempUri = new URI(gitRepoUri);
+                URI tempUri = new URI(preprocessSshRepoUri(gitRepoUri));
                 String gitRepoPath = tempUri.getPath().endsWith(".git") ? tempUri.getPath().substring(0, tempUri.getPath().length() - 4) : tempUri.getPath();
                 return Optional.of(new URI("https", tempUri.getHost(), gitRepoPath, null));
             } catch (URISyntaxException e) {
@@ -446,14 +446,15 @@ final class CustomBuildScanEnhancements {
             }
         }
 
-        private Optional<URI> stripDotGitExtension(URI uri) {
-            String path = uri.getPath();
-            try {
-                return path.endsWith(".git") ? Optional.of(new URI(uri.getScheme(), uri.getHost(), path.substring(0, path.length() - 4)))
-                    : Optional.of(uri);
-            } catch (URISyntaxException e) {
-                return Optional.empty();
+        private String preprocessSshRepoUri(String gitRepoUri) {
+            if (!gitRepoUri.startsWith("ssh://")
+                && gitRepoUri.contains("@")
+                && gitRepoUri.indexOf(':', gitRepoUri.indexOf('@')) != -1) {
+                StringBuilder sshGitRepoUri = new StringBuilder("ssh://").append(gitRepoUri);
+                sshGitRepoUri.setCharAt(sshGitRepoUri.indexOf(":", sshGitRepoUri.indexOf("@")), '/');
+                return sshGitRepoUri.toString();
             }
+            return gitRepoUri;
         }
     }
 
@@ -535,5 +536,4 @@ final class CustomBuildScanEnhancements {
             return providers.provider(() -> (String) gradle.getRootProject().findProperty(name));
         }
     }
-
 }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -269,10 +269,10 @@ final class CustomBuildScanEnhancements {
 
             if (isGitHubActions(providers)) {
                 Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
-                Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
+                Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY", providers);
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
-                if (gitHubUrl.isPresent() && gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                if (gitHubUrl.isPresent() && gitRepository.isPresent() && gitHubRunId.isPresent()) {
+                    buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));
@@ -397,9 +397,9 @@ final class CustomBuildScanEnhancements {
             }
 
             Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
-            Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
-            if (gitHubUrl.isPresent() && gitHubRepository.isPresent() && isNotEmpty(gitCommitId)) {
-                buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitHubRepository.get() + "/tree/" + gitCommitId);
+            Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY", providers);
+            if (gitHubUrl.isPresent() && gitRepository.isPresent() && isNotEmpty(gitCommitId)) {
+                buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitRepository.get() + "/tree/" + gitCommitId);
             } else if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
                 Optional<URI> gitRepoUri = toUri(gitRepo);
                 gitRepoUri.ifPresent(r -> {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -402,10 +402,10 @@ final class CustomBuildScanEnhancements {
                 if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
                     buildScan.link("GitHub source", gitHubUrl + "/" + gitHubRepository + "/tree/" + gitCommitId);
                 } else {
-                    Matcher matcher = Pattern.compile("(https://|git@)(.*?(github|gitlab).*?)[:|/](.*)").matcher(gitRepo);
+                    Matcher matcher = Pattern.compile("((https|ssh)://|.*?@)(.*?(github|gitlab).*?)[:/](.*)").matcher(gitRepo);
                     if (matcher.matches()) {
-                        String repoUrl = "https://" + matcher.group(2) + "/";
-                        String rawRepoPath = matcher.group(4);
+                        String repoUrl = "https://" + matcher.group(3) + "/";
+                        String rawRepoPath = matcher.group(5);
                         String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
                         if (gitRepo.contains("github")) {
                             buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -402,10 +402,10 @@ final class CustomBuildScanEnhancements {
                 if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
                     buildScan.link("GitHub source", gitHubUrl + "/" + gitHubRepository + "/tree/" + gitCommitId);
                 } else {
-                    Matcher matcher = Pattern.compile("((https|ssh)://|.*?@)(.*?(github|gitlab).*?)[:/](.*)").matcher(gitRepo);
+                    Matcher matcher = Pattern.compile("(https://|.*?@)(.*?(github|gitlab).*?)[:/](.*)").matcher(gitRepo);
                     if (matcher.matches()) {
-                        String repoUrl = "https://" + matcher.group(3) + "/";
-                        String rawRepoPath = matcher.group(5);
+                        String repoUrl = "https://" + matcher.group(2) + "/";
+                        String rawRepoPath = matcher.group(4);
                         String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
                         if (gitRepo.contains("github")) {
                             buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -361,6 +361,8 @@ final class CustomBuildScanEnhancements {
 
     private static final class CaptureGitMetadataAction implements Action<BuildScanExtension> {
 
+        private static final Pattern GIT_REPO_URI_PATTERN = Pattern.compile("^(?:https://|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$");
+
         private final ProviderFactory providers;
 
         private CaptureGitMetadataAction(ProviderFactory providers) {
@@ -404,11 +406,11 @@ final class CustomBuildScanEnhancements {
                 buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitRepository.get() + "/tree/" + gitCommitId);
             } else if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
                 Optional<URI> webRepoUri = toWebRepoUri(gitRepo);
-                webRepoUri.ifPresent(r -> {
-                    if (r.getHost().contains("github")) {
-                        buildScan.link("GitHub source", r + "/tree/" + gitCommitId);
-                    } else if (r.getHost().contains("gitlab")) {
-                        buildScan.link("GitLab source", r + "/-/commit/" + gitCommitId);
+                webRepoUri.ifPresent(uri -> {
+                    if (uri.getHost().contains("github")) {
+                        buildScan.link("GitHub source", uri + "/tree/" + gitCommitId);
+                    } else if (uri.getHost().contains("gitlab")) {
+                        buildScan.link("GitLab source", uri + "/-/commit/" + gitCommitId);
                     }
                 });
             }
@@ -439,7 +441,7 @@ final class CustomBuildScanEnhancements {
         }
 
         private Optional<URI> toWebRepoUri(String gitRepoUri) {
-            Matcher matcher = Pattern.compile("^(?:https://|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$").matcher(gitRepoUri);
+            Matcher matcher = GIT_REPO_URI_PATTERN.matcher(gitRepoUri);
             if (matcher.matches()) {
                 String scheme = "https";
                 String host = matcher.group(1);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -268,10 +268,11 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isGitHubActions(providers)) {
+                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
                 Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
-                if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                if (gitHubUrl.isPresent() && gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
+                    buildScan.link("GitHub Actions build", gitHubUrl.get() + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -271,8 +271,8 @@ final class CustomBuildScanEnhancements {
                 Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
                 Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
-                if (gitHubUrl.isPresent() && gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", gitHubUrl.get() + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
+                    buildScan.link("GitHub Actions build", gitHubUrl.orElse("https://github.com") + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -397,10 +397,10 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
-                Matcher matcher = Pattern.compile("(https://|git@)(.+?)[:|/](.*)").matcher(gitRepo);
+                Matcher matcher = Pattern.compile("(https?://|git@)(.*?(github|gitlab).*?)[:|/](.*)").matcher(gitRepo);
                 if (matcher.matches()) {
                     String repoUrl = "https://" + matcher.group(2) + "/";
-                    String rawRepoPath = matcher.group(3);
+                    String rawRepoPath = matcher.group(4);
                     String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
                     if (gitRepo.contains("github")) {
                         buildScan.link("Github source", repoUrl + repoPath + "/tree/" + gitCommitId);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -270,10 +270,10 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isGitHubActions(providers)) {
-                String gitHubUrl = envVariable("GITHUB_SERVER_URL", providers).orElse("https://github.com");
+                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
                 Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
-                if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
+                if (gitHubUrl.isPresent() && gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
                     buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -396,21 +396,19 @@ final class CustomBuildScanEnhancements {
                 buildScan.value("Git status", gitStatus);
             }
 
-            if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
-                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
-                Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
-                if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
-                    buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitHubRepository.get() + "/tree/" + gitCommitId);
-                } else {
-                    Matcher matcher = Pattern.compile("(?:https://|.*?@)(.*?(?:github|gitlab).*?)[:/](.*)\\.git").matcher(gitRepo);
-                    if (matcher.matches()) {
-                        String repoUrl = "https://" + matcher.group(1) + "/";
-                        String repoPath = matcher.group(2);
-                        if (gitRepo.contains("github")) {
-                            buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);
-                        } else if (gitRepo.contains("gitlab")) {
-                            buildScan.link("GitLab source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
-                        }
+            Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
+            Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
+            if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
+                buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitHubRepository.get() + "/tree/" + gitCommitId);
+            } else if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
+                Matcher matcher = Pattern.compile("(?:https://|.*?@)(.*?(?:github|gitlab).*?)[:/](.*)\\.git").matcher(gitRepo);
+                if (matcher.matches()) {
+                    String repoUrl = "https://" + matcher.group(1) + "/";
+                    String repoPath = matcher.group(2);
+                    if (gitRepo.contains("github")) {
+                        buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);
+                    } else if (gitRepo.contains("gitlab")) {
+                        buildScan.link("GitLab source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
                     }
                 }
             }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -447,14 +447,13 @@ final class CustomBuildScanEnhancements {
         }
 
         private String preprocessSshRepoUri(String gitRepoUri) {
-            if (!gitRepoUri.startsWith("ssh://")
-                && gitRepoUri.contains("@")
-                && gitRepoUri.indexOf(':', gitRepoUri.indexOf('@')) != -1) {
-                StringBuilder sshGitRepoUri = new StringBuilder("ssh://").append(gitRepoUri);
-                sshGitRepoUri.setCharAt(sshGitRepoUri.indexOf(":", sshGitRepoUri.indexOf("@")), '/');
-                return sshGitRepoUri.toString();
+            if (gitRepoUri.startsWith("git@github.com:")) {
+                return gitRepoUri.replace("git@github.com:", "ssh://git@github.com/");
+            } else if (gitRepoUri.startsWith("git@gitlab.com:")) {
+                return gitRepoUri.replace("git@gitlab.com:", "ssh://git@gitlab.com/");
+            } else {
+                return gitRepoUri;
             }
-            return gitRepoUri;
         }
     }
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -268,11 +268,11 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isGitHubActions(providers)) {
-                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
+                String gitHubUrl = envVariable("GITHUB_SERVER_URL", providers).orElse("https://github.com");
                 Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
                 if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", gitHubUrl.orElse("https://github.com") + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                    buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -397,15 +397,21 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
-                Matcher matcher = Pattern.compile("(https://|git@)(.*?(github|gitlab).*?)[:|/](.*)").matcher(gitRepo);
-                if (matcher.matches()) {
-                    String repoUrl = "https://" + matcher.group(2) + "/";
-                    String rawRepoPath = matcher.group(4);
-                    String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                    if (gitRepo.contains("github")) {
-                        buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);
-                    } else if (gitRepo.contains("gitlab")) {
-                        buildScan.link("GitLab source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
+                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
+                Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
+                if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
+                    buildScan.link("GitHub source", gitHubUrl + "/" + gitHubRepository + "/tree/" + gitCommitId);
+                } else {
+                    Matcher matcher = Pattern.compile("(https://|git@)(.*?(github|gitlab).*?)[:|/](.*)").matcher(gitRepo);
+                    if (matcher.matches()) {
+                        String repoUrl = "https://" + matcher.group(2) + "/";
+                        String rawRepoPath = matcher.group(4);
+                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
+                        if (gitRepo.contains("github")) {
+                            buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);
+                        } else if (gitRepo.contains("gitlab")) {
+                            buildScan.link("GitLab source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -400,7 +400,7 @@ final class CustomBuildScanEnhancements {
                 Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
                 Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY", providers);
                 if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
-                    buildScan.link("GitHub source", gitHubUrl + "/" + gitHubRepository + "/tree/" + gitCommitId);
+                    buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitHubRepository.get() + "/tree/" + gitCommitId);
                 } else {
                     Matcher matcher = Pattern.compile("(?:https://|.*?@)(.*?(?:github|gitlab).*?)[:/](.*)\\.git").matcher(gitRepo);
                     if (matcher.matches()) {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -403,12 +403,13 @@ final class CustomBuildScanEnhancements {
             } else if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
                 Optional<URI> gitRepoUri = toUri(gitRepo);
                 gitRepoUri.ifPresent(r -> {
-                    String gitRepoHost = r.getHost();
                     String gitRepoPath = r.getPath().endsWith(".git") ? r.getPath().substring(0, r.getPath().length() - 4) : r.getPath();
-                    if (gitRepoHost.contains("github")) {
-                        buildScan.link("GitHub source", "https://" + gitRepoHost + gitRepoPath + "/tree/" + gitCommitId);
-                    } else if (gitRepoHost.contains("gitlab")) {
-                        buildScan.link("GitLab source", "https://" + gitRepoHost + gitRepoPath + "/-/commit/" + gitCommitId);
+                    if (r.getHost().contains("github")) {
+                        toHttpsUri(r.getHost(), gitRepoPath + "/tree/" + gitCommitId)
+                            .ifPresent(u ->  buildScan.link("GitHub source", u.toString()));
+                    } else if (r.getHost().contains("gitlab")) {
+                        toHttpsUri(r.getHost(), gitRepoPath + "/-/commit/" + gitCommitId)
+                            .ifPresent(u -> buildScan.link("GitLab source", u.toString()));
                     }
                 });
             }
@@ -446,6 +447,13 @@ final class CustomBuildScanEnhancements {
             }
         }
 
+        private Optional<URI> toHttpsUri(String host, String path) {
+            try {
+                return Optional.of(new URI("https", host, path));
+            } catch (URISyntaxException e) {
+                return Optional.empty();
+            }
+        }
     }
 
     private void captureTestParallelization() {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -397,7 +397,7 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
-                Matcher matcher = Pattern.compile("(https?://|git@)(.*?(github|gitlab).*?)[:|/](.*)").matcher(gitRepo);
+                Matcher matcher = Pattern.compile("(https://|git@)(.*?(github|gitlab).*?)[:|/](.*)").matcher(gitRepo);
                 if (matcher.matches()) {
                     String repoUrl = "https://" + matcher.group(2) + "/";
                     String rawRepoPath = matcher.group(4);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -405,8 +405,13 @@ final class CustomBuildScanEnhancements {
             if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
                 buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitHubRepository.get() + "/tree/" + gitCommitId);
             } else if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
+                Optional<URI> gitRepoUriOpt = Optional.empty();
                 try {
-                    URI gitRepoUri = new URI(gitRepo);
+                    gitRepoUriOpt = Optional.of(new URI(gitRepo));
+                } catch (URISyntaxException e) {
+                    logger.warn("Remote git repository " + gitRepo + " is not a valid URI");
+                }
+                gitRepoUriOpt.ifPresent(gitRepoUri -> {
                     String gitRepoHost = gitRepoUri.getHost();
                     String gitRepoPath = gitRepoUri.getPath().endsWith(".git") ? gitRepoUri.getPath().substring(0, gitRepoUri.getPath().length() - 4) : gitRepoUri.getPath();
                     if (gitRepo.contains("github")) {
@@ -414,9 +419,7 @@ final class CustomBuildScanEnhancements {
                     } else if (gitRepo.contains("gitlab")) {
                         buildScan.link("GitLab source", "https://" + gitRepoHost + gitRepoPath + "/-/commit/" + gitCommitId);
                     }
-                } catch (URISyntaxException e) {
-                    logger.warn("Remote git repository " + gitRepo + " is not a valid URI");
-                }
+                });
             }
         }
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -403,9 +403,9 @@ final class CustomBuildScanEnhancements {
                     String rawRepoPath = matcher.group(4);
                     String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
                     if (gitRepo.contains("github")) {
-                        buildScan.link("Github source", repoUrl + repoPath + "/tree/" + gitCommitId);
+                        buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);
                     } else if (gitRepo.contains("gitlab")) {
-                        buildScan.link("GitLab Source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
+                        buildScan.link("GitLab source", repoUrl + repoPath + "/-/commit/" + gitCommitId);
                     }
                 }
             }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -402,11 +402,10 @@ final class CustomBuildScanEnhancements {
                 if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
                     buildScan.link("GitHub source", gitHubUrl + "/" + gitHubRepository + "/tree/" + gitCommitId);
                 } else {
-                    Matcher matcher = Pattern.compile("(?:https://|.*?@)(.*?(?:github|gitlab).*?)[:/](.*)").matcher(gitRepo);
+                    Matcher matcher = Pattern.compile("(?:https://|.*?@)(.*?(?:github|gitlab).*?)[:/](.*)\\.git").matcher(gitRepo);
                     if (matcher.matches()) {
                         String repoUrl = "https://" + matcher.group(1) + "/";
-                        String rawRepoPath = matcher.group(2);
-                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
+                        String repoPath = matcher.group(2);
                         if (gitRepo.contains("github")) {
                             buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);
                         } else if (gitRepo.contains("gitlab")) {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -402,10 +402,10 @@ final class CustomBuildScanEnhancements {
                 if (gitHubUrl.isPresent() && gitHubRepository.isPresent()) {
                     buildScan.link("GitHub source", gitHubUrl + "/" + gitHubRepository + "/tree/" + gitCommitId);
                 } else {
-                    Matcher matcher = Pattern.compile("(https://|.*?@)(.*?(github|gitlab).*?)[:/](.*)").matcher(gitRepo);
+                    Matcher matcher = Pattern.compile("(?:https://|.*?@)(.*?(?:github|gitlab).*?)[:/](.*)").matcher(gitRepo);
                     if (matcher.matches()) {
-                        String repoUrl = "https://" + matcher.group(2) + "/";
-                        String rawRepoPath = matcher.group(4);
+                        String repoUrl = "https://" + matcher.group(1) + "/";
+                        String rawRepoPath = matcher.group(2);
                         String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
                         if (gitRepo.contains("github")) {
                             buildScan.link("GitHub source", repoUrl + repoPath + "/tree/" + gitCommitId);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -414,9 +414,9 @@ final class CustomBuildScanEnhancements {
                 gitRepoUriOpt.ifPresent(gitRepoUri -> {
                     String gitRepoHost = gitRepoUri.getHost();
                     String gitRepoPath = gitRepoUri.getPath().endsWith(".git") ? gitRepoUri.getPath().substring(0, gitRepoUri.getPath().length() - 4) : gitRepoUri.getPath();
-                    if (gitRepo.contains("github")) {
+                    if (gitRepoHost.contains("github")) {
                         buildScan.link("GitHub source", "https://" + gitRepoHost + gitRepoPath + "/tree/" + gitCommitId);
-                    } else if (gitRepo.contains("gitlab")) {
+                    } else if (gitRepoHost.contains("gitlab")) {
                         buildScan.link("GitLab source", "https://" + gitRepoHost + gitRepoPath + "/-/commit/" + gitCommitId);
                     }
                 });


### PR DESCRIPTION
Fixes #109

When creating links to GitHub Actions builds, the plugin now references the environment variable `GITHUB_SERVER_URL` instead of hardcoding `https://github.com/`.

When creating build scan links to the remote repository, the plugin now uses a regex to parse out the correct url instead of hardcoding `https://github.com/` or `https://gitlab.com`.

### Local Tests

Published the CCUD plugin to Maven local for testing.

HTTP URL variations tested:
* `https://github.com/gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/r4phrtqudyt2y
* `https://github.com:443/gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/lbibg7tgoq6ea
* `https://github.somecompany.com/gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/njk2dgwc74j6y
* `https://github.somecompany.com//gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/zz6ohiobmry7c
* `https://gh.somecompany.com/gradle/common-custom-user-data-gradle-plugin.git` (no link is generated): https://ge.solutions-team.gradle.com/s/qdxgbegbcfrt6

SSH URL variations tested:
* `git@github.com:gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/wjuxfu2vcgewc
* `ssh://git@github.com/gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/f34u7kk3y4csc
* `ssh://git@github.com:22/gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/uvk6gngtx4nxo
* `git@github.somecompany.com:gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/axzabanengtm6
* `git@gh.somecompany.com:gradle/common-custom-user-data-gradle-plugin.git` (no link is generated): https://ge.solutions-team.gradle.com/s/32oxx7u7vw4oi

### CI Tests

Published the CCUD plugin `1.10.1` to the plugin portal for CI testing.

A branch was created `tylerbertrand/test-pr-150` and pushed that uses `1.10.1` from the staging portal to test the custom link generation in CI builds.

[This GitHub Actions build](https://github.com/gradle/common-custom-user-data-gradle-plugin/actions/runs/4633501276) created the build scan https://ge.solutions-team.gradle.com/s/3e3cjt4ncw2oo. The correct `GitHub source` custom link was created, and based on the tags, it is clear the build executed in CI. It can be verified [here](https://ge.solutions-team.gradle.com/s/3e3cjt4ncw2oo/build-dependencies?focusedDependency=WzAsMSwxLFswLDEsWzFdXV0&toggled=W1swXSxbMCwxXV0) that the CCUD plugin used was `1.10.1` from the staging portal.