### PR TITLE
Add release notes to plugin description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,16 +38,12 @@ gradlePlugin {
 
     automatedPublishing = true
 
-    def releaseNotes = layout.projectDirectory.file('release/changes.md').asFile.text
+    def releaseNotesFile = layout.projectDirectory.file('release/changes.md')
     plugins {
         commonCustomUserData {
             id = 'com.gradle.common-custom-user-data-gradle-plugin'
             displayName = 'Gradle Enterprise Common Custom User Data Gradle Plugin'
-            description = """\
-                          |A Gradle plugin to capture common custom user data used for Gradle Build Scans in Gradle Enterprise
-                          |
-                          |$releaseNotes
-                          """.stripMargin().trim()
+            description = providers.fileContents(releaseNotesFile).asText.get().trim()
             implementationClass = 'com.gradle.CommonCustomUserDataGradlePlugin'
             tags.addAll('android', 'java', 'gradle enterprise')
         }

--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,11 @@ gradlePlugin {
 
     automatedPublishing = true
 
-    def releaseNotesFile = layout.projectDirectory.file('release/changes.md')
     plugins {
         commonCustomUserData {
             id = 'com.gradle.common-custom-user-data-gradle-plugin'
             displayName = 'Gradle Enterprise Common Custom User Data Gradle Plugin'
-            description = providers.fileContents(releaseNotesFile).asText.get().trim()
+            description = releaseNotes().get()
             implementationClass = 'com.gradle.CommonCustomUserDataGradlePlugin'
             tags.addAll('android', 'java', 'gradle enterprise')
         }
@@ -105,4 +104,9 @@ def gitHubReleaseName() {
 
 def gitReleaseTag() {
     return "v${version}"
+}
+
+def releaseNotes() {
+    def releaseNotesFile = layout.projectDirectory.file('release/changes.md')
+    return providers.fileContents(releaseNotesFile).asText.map { it -> it.trim() }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -72,16 +72,16 @@ signing {
 }
 
 githubRelease {
-   token = System.getenv('CCUD_GIT_TOKEN') ?: ''
-   owner = 'gradle'
-   repo = 'common-custom-user-data-gradle-plugin'
-   targetCommitish = 'main'
-   releaseName = gitHubReleaseName()
-   tagName = gitReleaseTag()
-   prerelease = false
-   overwrite = false
-   generateReleaseNotes = false
-   body = releaseNotes()
+    token = System.getenv('CCUD_GIT_TOKEN') ?: ''
+    owner = 'gradle'
+    repo = 'common-custom-user-data-gradle-plugin'
+    targetCommitish = 'main'
+    releaseName = gitHubReleaseName()
+    tagName = gitReleaseTag()
+    prerelease = false
+    overwrite = false
+    generateReleaseNotes = false
+    body = releaseNotes()
 }
 
 def createReleaseTag = tasks.register('createReleaseTag', CreateGitTag) {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ githubRelease {
    prerelease = false
    overwrite = false
    generateReleaseNotes = false
-   body = layout.projectDirectory.file('release/changes.md').asFile.text.trim()
+   body = releaseNotes()
 }
 
 def createReleaseTag = tasks.register('createReleaseTag', CreateGitTag) {

--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,16 @@ gradlePlugin {
 
     automatedPublishing = true
 
+    def releaseNotes = layout.projectDirectory.file('release/changes.md').asFile.text
     plugins {
         commonCustomUserData {
             id = 'com.gradle.common-custom-user-data-gradle-plugin'
             displayName = 'Gradle Enterprise Common Custom User Data Gradle Plugin'
-            description = 'A Gradle plugin to capture common custom user data used for Gradle Build Scans in Gradle Enterprise'
+            description = """\
+                          |A Gradle plugin to capture common custom user data used for Gradle Build Scans in Gradle Enterprise
+                          |
+                          |$releaseNotes
+                          """.stripMargin().trim()
             implementationClass = 'com.gradle.CommonCustomUserDataGradlePlugin'
             tags.addAll('android', 'java', 'gradle enterprise')
         }

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 
 group = 'com.gradle'
 version = layout.projectDirectory.file('release/version.txt').asFile.text.trim()
+description = 'A Gradle plugin to capture common custom user data used for Gradle Build Scans in Gradle Enterprise'
 
 repositories {
     gradlePluginPortal()


### PR DESCRIPTION
Resolves #134

Allows users to view release notes from the plugin portal and gives them an idea of what will be gained by updating to that version.

The contents of the release notes file are read in a way that supports configuration caching using `Providers.fileContents()`. This functionality was extracted into its own method, and setting `githubRelease.body` has been updated to use this. 

Configuration cache compatibility was verified using the following steps...
1. Run `./gradlew clean`
2. Run `./gradlew generatePomFileForCommonCustomUserDataPluginMarkerMavenPublication` to generate the `build/publications/commonCustomUserDataPluginMarkerMaven/pom-default.xml` file containing the release notes in `release/changes.md`. The logs indicate a new configuration cache entry has been stored.
3. Run `./gradlew generatePomFileForCommonCustomUserDataPluginMarkerMavenPublication` again without changes. The logs indicate the configuration cache entry has been re-used. The contents of `pom-default.xml` have not changed.
4. Make changes to `release/changes.md`
5. Re-run `./gradlew generatePomFileForCommonCustomUserDataPluginMarkerMavenPublication`. The logs indicate a new configuration cache entry has been stored. A new `pom-default.xml` has been generated with a description reflecting the changes to `release/changes.md`.

Also corrected `githubRelease` closure indent from 3 spaces to 4. All other indentation is 4 spaces.

[CCUD plugin in the staging portal](https://plugins.grdev.net/plugin/com.gradle.common-custom-user-data-gradle-plugin)

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/121591679/229922662-0120b9fb-1054-4218-9ca0-14f339c384db.png">

