### PR TITLE
Call .get() on optional gitHubUrl

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -274,7 +274,7 @@ final class CustomBuildScanEnhancements {
                 Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY", providers);
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
                 if (gitHubUrl.isPresent() && gitRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                    buildScan.link("GitHub Actions build", gitHubUrl.get() + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));


### PR DESCRIPTION
Fixes "GitHub Actions build" (and others) custom link creation failure caused by neglecting to call `.get()` on optional `gitHubUrl`.

GitHub Actions [build scan](https://ge.solutions-team.gradle.com/s/kfjkhd2o4kspi) verifying that all custom links are correctly created.

GitHub Actions [build scan](https://ge.solutions-team.gradle.com/s/3e3cjt4ncw2oo) before this fix was applied. Notice the missing custom links.