### PR TITLE
Set version to String

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ def releaseVersion = releaseVersion()
 def releaseNotes = releaseNotes()
 
 group = 'com.gradle'
-version = releaseVersion
+version = releaseVersion.get()
 description = 'A Gradle plugin to capture common custom user data used for Gradle Build Scans in Gradle Enterprise'
 
 repositories {


### PR DESCRIPTION
Setting version to `Property<String>` causes incorrect jar file names and incorrect version in pom files, as other tasks do not account for `version` (which is of type `Object`) being a `Property`.

Though this results in the version file being read eagerly, we still have achieved the main goal of configuration cache compatibility when reading the version file.

### Tests
* `./gradlew clean generatePomFileForCommonCustomUserDataPluginMarkerMavenPublication` generates correct version in `pom-default.xml`: `<version>1.10.11</version>`
* `./gradlew clean generatePomFileForCommonCustomUserDataPluginMarkerMavenPublication` stores new configuration cache entry when `version.txt` is updated, and the configuration cache entry is reused when it has not been updated. The version in `pom-default.xml` is updated accordingly.
* Published CCUD plugin `1.10.11` to `mavenLocal()` and successfully included it as a dependency: [build scan](https://ge.solutions-team.gradle.com/s/onqq2nh6mv2zi/build-dependencies?focusedDependency=WzAsMSwxLFswLDEsWzFdXV0&toggled=W1swXSxbMCwxXSxbMCwxLFsxXV1d)