### PR TITLE
Refactor to avoid NPE with equals

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -118,7 +118,7 @@ final class CustomBuildScanEnhancements {
                 if (ideaVendorNameValue.equals("Google")) {
                     // using androidStudioVersion instead of ideaVersion for compatibility reasons, those can be different (e.g. 2020.3.1 Patch 3 instead of 2020.3)
                     tagIde("Android Studio", getOrEmpty(props.get(PROJECT_PROP_ANDROID_STUDIO_VERSION)));
-                } else if (ideaVendorNameValue.equals("JetBrains")) {
+                } else if ("Jetbrains".equals(ideaVendorNameValue)) {
                     tagIde("IntelliJ IDEA", getOrEmpty(props.get(SYSTEM_PROP_IDEA_VERSION)));
                 }
             } else if (props.get(PROJECT_PROP_ANDROID_INVOKED_FROM_IDE).isPresent()) {


### PR DESCRIPTION
The literal is placed on the left side of the expression to avoid a possible NPE

This is a follow up on https://github.com/gradle/common-custom-user-data-maven-extension/pull/127
