### PR TITLE
Handle embedded user info in git repo url

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [FIX] Generates incorrect links to source repositories when repository URL contains embedded user info

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 
 final class Utils {
 
-    private static final Pattern GIT_REPO_URI_PATTERN = Pattern.compile("^(?:(?:https://|git://)|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$");
+    private static final Pattern GIT_REPO_URI_PATTERN = Pattern.compile("^(?:(?:https://|git://)(?:.+:.+@)?|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$");
 
     static Optional<String> sysPropertyOrEnvVariable(String sysPropertyName, String envVarName, ProviderFactory providers) {
         Optional<String> sysProperty = sysProperty(sysPropertyName, providers);

--- a/src/test/java/com/gradle/UtilsTest.java
+++ b/src/test/java/com/gradle/UtilsTest.java
@@ -1,22 +1,64 @@
 package com.gradle;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.net.URI;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.gradle.Utils.toWebRepoUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UtilsTest {
-    @Test
-    public void toWebRepoUri_git() {
-        assertEquals(URI.create("https://github.com/acme-inc/my-project"), toWebRepoUri("git://github.com/acme-inc/my-project.git").get());
-        assertEquals(URI.create("https://gitlab.com/acme-inc/my-project"), toWebRepoUri("git://gitlab.com/acme-inc/my-project.git").get());
+
+    @ParameterizedTest
+    @ArgumentsSource(WebRepoUriArgumentsProvider.class)
+    public void testToWebRepoUri(String repositoryHost, String repositoryUri) {
+        URI expectedWebRepoUri = URI.create(String.format("https://%s.com/acme-inc/my-project", repositoryHost));
+        assertEquals(Optional.of(expectedWebRepoUri), toWebRepoUri(String.format(repositoryUri, repositoryHost)));
     }
 
-    @Test
-    public void toWebRepoUri_https() {
-        assertEquals(URI.create("https://github.com/acme-inc/my-project"), toWebRepoUri("https://github.com/acme-inc/my-project").get());
-        assertEquals(URI.create("https://gitlab.com/acme-inc/my-project"), toWebRepoUri("https://gitlab.com/acme-inc/my-project").get());
+    @ParameterizedTest
+    @ArgumentsSource(EnterpriseWebRepoUriArgumentsProvider.class)
+    public void testToWebRepoUri_enterpriseUri(String repositoryHost, String repositoryUri) {
+        URI expectedWebRepoUri = URI.create(String.format("https://%s.acme.com/acme-inc/my-project", repositoryHost));
+        assertEquals(Optional.of(expectedWebRepoUri), toWebRepoUri(String.format(repositoryUri, repositoryHost)));
+    }
+
+    private static class WebRepoUriArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            Set<String> host = Stream.of("github", "gitlab").collect(Collectors.toSet());
+            Set<String> remoteRepositoryUris = Stream.of(
+                    "https://%s.com/acme-inc/my-project",
+                    "https://%s.com:443/acme-inc/my-project",
+                    "https://user:secret@%s.com/acme-inc/my-project",
+                    "ssh://git@%s.com/acme-inc/my-project.git",
+                    "ssh://git@%s.com:22/acme-inc/my-project.git",
+                    "git://%s.com/acme-inc/my-project.git",
+                    "git@%s.com/acme-inc/my-project.git"
+            ).collect(Collectors.toSet());
+            return host.stream().flatMap(h -> remoteRepositoryUris.stream().map(r -> Arguments.arguments(h, r)));
+        }
+    }
+
+    private static class EnterpriseWebRepoUriArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            Set<String> host = Stream.of("github", "gitlab").collect(Collectors.toSet());
+            Set<String> remoteRepositoryUris = Stream.of(
+                    "https://%s.acme.com/acme-inc/my-project",
+                    "git@%s.acme.com/acme-inc/my-project.git"
+            ).collect(Collectors.toSet());
+            return host.stream().flatMap(h -> remoteRepositoryUris.stream().map(r -> Arguments.arguments(h, r)));
+        }
     }
 }


### PR DESCRIPTION
Fixes #191

Update `GIT_REPO_URI_PATTERN` to properly handle embedded user info in git repository URL

### Tests
* `https://gitlab-svc-user:secret@gitlab.self-hosted.com/foo/bar.git`: https://ge.solutions-team.gradle.com/s/b54q5wdxtkef4#info
* `https://github.com/gradle/common-custom-user-data-gradle-plugin.git`: https://ge.solutions-team.gradle.com/s/yv6hrmnldvo3e#info