### PR TITLE
Remove maxParallelForks custom value

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+[NEW] Remove `maxParallelForks` custom value

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -78,7 +78,6 @@ final class CustomBuildScanEnhancements {
         captureCiOrLocal();
         captureCiMetadata();
         captureGitMetadata();
-        captureTestParallelization();
     }
 
     private void captureOs() {
@@ -459,30 +458,6 @@ final class CustomBuildScanEnhancements {
             return gitCommand.get();
         }
 
-    }
-
-    private void captureTestParallelization() {
-        gradle.afterProject(p -> {
-            TaskCollection<Test> tests = p.getTasks().withType(Test.class);
-            if (isGradle5OrNewer()) {
-                tests.configureEach(captureMaxParallelForks(buildScan));
-            } else {
-                tests.all(captureMaxParallelForks(buildScan));
-            }
-        });
-    }
-
-    private static Action<Test> captureMaxParallelForks(BuildScanExtension buildScan) {
-        return test -> {
-            test.doFirst(new Action<Task>() {
-                // use anonymous inner class to keep Test task instance cacheable
-                // additionally, using lambdas as task actions is deprecated
-                @Override
-                public void execute(Task task) {
-                    buildScan.value(test.getIdentityPath() + "#maxParallelForks", String.valueOf(test.getMaxParallelForks()));
-                }
-            });
-        };
     }
 
     private static void addCustomValueAndSearchLink(BuildScanExtension buildScan, String name, String value) {


### PR DESCRIPTION
Adding a maxParallelForks custom value for each test task caused sometimes unnecessary noise in build scans. An example of how to add this custom value has instead been added to the build config samples repository ([link](https://github.com/gradle/gradle-enterprise-build-config-samples/tree/main/build-data-capturing-gradle-samples/capture-max-parallel-forks)).

[Build scan](https://ge.solutions-team.gradle.com/s/dy4iiufwyn24c/custom-values) showing custom values with [CCUD plugin including these changes applied](https://ge.solutions-team.gradle.com/s/dy4iiufwyn24c/build-dependencies?focusedDependency=WzAsMSwxLFswLDEsWzFdXV0&focusedDependencyView=details&toggled=W1swXSxbMCwxXV0) no longer include `maxParallelForks`

Verified functional tests pass when setting `commonCustomUserDataPluginProjectDir` to this repository with these changes.

