### PR TITLE
Use gradle/actions/setup-gradle and gradle/actions/dependency-submission

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -15,7 +15,7 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Build with Gradle
         run: ./gradlew build -x signPluginMavenPublication -i -Porg.gradle.java.installations.auto-download=false
         env:

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -17,7 +17,7 @@ jobs:
         distribution: temurin
         java-version: 8
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         dependency-graph: generate-and-submit
     - name: Run assemble to generate dependency graph

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -17,10 +17,6 @@ jobs:
         distribution: temurin
         java-version: 8
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        dependency-graph: generate-and-submit
-    - name: Run assemble to generate dependency graph
-      run: ./gradlew assemble -x signPluginMavenPublication -i -Porg.gradle.java.installations.auto-download=false
+      uses: gradle/actions/dependency-submission@v3
       env:
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}

--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Upgrade Wrappers
         run: ./gradlew clean upgradeGradleWrapperAll --continue -Porg.gradle.java.installations.auto-download=false
         env:


### PR DESCRIPTION
- Replaces use of `gradle/gradle-build-action` with `gradle/actions/setup-gradle`.
- Replaces custom dependency graph workflow with simpler one using `gradle/actions/dependency-submission`.