### PR TITLE
Improve tags/values in Jenkins where `GIT_BRANCH` is available

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [NEW] Improve tags/values in Jenkins where `GIT_BRANCH` is available

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -7,14 +7,18 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -437,9 +441,17 @@ final class CustomBuildScanEnhancements {
 
         private String getGitBranchName(Supplier<String> gitCommand) {
             if (isJenkins(providers) || isHudson(providers)) {
-                Optional<String> branch = envVariable("BRANCH_NAME", providers);
-                if (branch.isPresent()) {
-                    return branch.get();
+                Optional<String> branchName = envVariable("BRANCH_NAME", providers);
+                if (branchName.isPresent()) {
+                    return branchName.get();
+                }
+
+                Optional<String> gitBranch = envVariable("GIT_BRANCH", providers);
+                if (gitBranch.isPresent()) {
+                    Optional<String> localBranch = getLocalBranch(gitBranch.get());
+                    if (localBranch.isPresent()) {
+                        return localBranch.get();
+                    }
                 }
             } else if (isGitLab(providers)) {
                 Optional<String> branch = envVariable("CI_COMMIT_REF_NAME", providers);
@@ -460,6 +472,19 @@ final class CustomBuildScanEnhancements {
             return gitCommand.get();
         }
 
+        private static Optional<String> getLocalBranch(String remoteBranch) {
+            // This finds the longest matching remote name. This is because, for example, a local git clone could have
+            // two remotes named `origin` and `origin/two`. In this scenario, we would want a remote branch of
+            // `origin/two/main` to match to the `origin/two` remote, not to `remote`
+            Function<String, Optional<String>> findLongestMatchingRemote = remotes -> Arrays.stream(remotes.split("\\R"))
+                    .filter(remote -> remoteBranch.startsWith(remote + "/"))
+                    .max(Comparator.comparingInt(String::length));
+
+            return Optional.ofNullable(execAndGetStdOut("git", "remote"))
+                    .filter(Utils::isNotEmpty)
+                    .flatMap(findLongestMatchingRemote)
+                    .map(remote -> remoteBranch.replaceFirst("^" + remote + "/", ""));
+        }
     }
 
     private static void addCustomValueAndSearchLink(BuildScanExtension buildScan, String name, String value) {


### PR DESCRIPTION
For Jenkins builds where the [Check out to specific local branch](https://plugins.jenkins.io/git/#plugin-content-checkout-to-specific-local-branch) functionality is not enabled, Jenkins provides a `GIT_BRANCH` environment variable that contains the name of the branch that was checked out, including the remote. In this scenario, CCUD detects the branch name as `HEAD`, leading to tags and values in Build Scans that do not provide details on the branch from which they were published.

This PR will provide better tags and values for these builds by reading the value of `GIT_BRANCH`, when present, and using its value as the branch name, rather than the less useful value of `HEAD`

Once these changes are merged, the same changes will be made in Common Custom User Data Maven Extension.