### PR TITLE
Fix the usage of `orElse` provider API

### DIFF
--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -190,6 +190,10 @@ final class Utils {
         return isGradleNewerThan("5.0");
     }
 
+    static boolean isGradle56OrNewer() {
+        return isGradleNewerThan("5.6");
+    }
+
     static boolean isGradle6OrNewer() {
         return isGradleNewerThan("6.0");
     }


### PR DESCRIPTION
The `orElse` API is available only starting with Gradle 5.6: https://e.grdev.net/s/zna6geusbluio/tests/task/:common-custom-user-data-gradle-plugin-test-func:test_Gradle_4_10_3_GradleJDK_11_daily/details/com.gradle.custom.CommonCustomUserDataGradlePluginFuncTest/Checking%20IDE%20tags%20and%20custom%20values%20for%20New%20IJ%20version%20%5BbuildToolVersion%3D4.10.3%2C%20gradleJavaVersion%3D11%5D?focused-exception-line=0-11&top-execution=1

Caused by https://github.com/gradle/common-custom-user-data-gradle-plugin/commit/90c8241ebd387910a043d4edda488f479e6f58fc