### PR TITLE
Revert detached head detection

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,1 @@
-- [NEW] Improve tags/values in GitHub Actions `pull_request` workflows
 - [NEW] Improve tags/values in Jenkins where `GIT_BRANCH` is available

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,0 @@
-- [NEW] Improve tags/values in Jenkins where `GIT_BRANCH` is available

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -7,18 +7,14 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
-import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -442,17 +438,9 @@ final class CustomBuildScanEnhancements {
 
         private String getGitBranchName(Supplier<String> gitCommand) {
             if (isJenkins(providers) || isHudson(providers)) {
-                Optional<String> branchName = envVariable("BRANCH_NAME", providers);
-                if (branchName.isPresent()) {
-                    return branchName.get();
-                }
-
-                Optional<String> gitBranch = envVariable("GIT_BRANCH", providers);
-                if (gitBranch.isPresent()) {
-                    Optional<String> localBranch = getLocalBranch(gitBranch.get());
-                    if (localBranch.isPresent()) {
-                        return localBranch.get();
-                    }
+                Optional<String> branch = envVariable("BRANCH_NAME", providers);
+                if (branch.isPresent()) {
+                    return branch.get();
                 }
             } else if (isGitLab(providers)) {
                 Optional<String> branch = envVariable("CI_COMMIT_REF_NAME", providers);
@@ -473,19 +461,6 @@ final class CustomBuildScanEnhancements {
             return gitCommand.get();
         }
 
-        private static Optional<String> getLocalBranch(String remoteBranch) {
-            // This finds the longest matching remote name. This is because, for example, a local git clone could have
-            // two remotes named `origin` and `origin/two`. In this scenario, we would want a remote branch of
-            // `origin/two/main` to match to the `origin/two` remote, not to `origin`
-            Function<String, Optional<String>> findLongestMatchingRemote = remotes -> Arrays.stream(remotes.split("\\R"))
-                    .filter(remote -> remoteBranch.startsWith(remote + "/"))
-                    .max(Comparator.comparingInt(String::length));
-
-            return Optional.ofNullable(execAndGetStdOut("git", "remote"))
-                    .filter(Utils::isNotEmpty)
-                    .flatMap(findLongestMatchingRemote)
-                    .map(remote -> remoteBranch.replaceFirst("^" + remote + "/", ""));
-        }
     }
 
     private static void addCustomValueAndSearchLink(BuildScanExtension buildScan, String name, String value) {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -285,8 +285,6 @@ final class CustomBuildScanEnhancements {
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI run", value));
-                envVariable("GITHUB_HEAD_REF", providers).ifPresent(value ->
-                        buildScan.value("PR branch", value));
             }
 
             if (isGitLab(providers)) {
@@ -468,11 +466,6 @@ final class CustomBuildScanEnhancements {
                 }
             } else if (isBuildkite(providers)) {
                 Optional<String> branch = envVariable("BUILDKITE_BRANCH", providers);
-                if (branch.isPresent()) {
-                    return branch.get();
-                }
-            } else if (isGitHubActions(providers)) {
-                Optional<String> branch = envVariable("GITHUB_REF_NAME", providers);
                 if (branch.isPresent()) {
                     return branch.get();
                 }


### PR DESCRIPTION
Revert detached head detection as it introduces breaking changes. Will get reapplied after a minor release.

This PR reverts the following PRs:
PR #240 - Improve tags/values in GitHub Actions pull_request workflows using git detached HEAD state
PR #270  - Improve tags/values in Jenkins where GIT_BRANCH is available