### PR TITLE
Reapply detached head work

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,2 @@
+- [NEW] Improve tags/values in GitHub Actions `pull_request` workflows
+- [NEW] Improve tags/values in Jenkins where `GIT_BRANCH` is available


### PR DESCRIPTION
This reverts commit 27fd312e681f06606a2c1512916dfb3cdc4a147a (PR #276 merge)

Effectively, this re-applies work done in PRs:

PR https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/240 - Improve tags/values in GitHub Actions pull_request workflows using git detached HEAD state
PR https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/270 - Improve tags/values in Jenkins where GIT_BRANCH is available