### PR TITLE
Use "Terms of Use" terminology instead of "Terms of Service"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
     maven {
         url = uri("https://repo.grdev.net/artifactory/public")
         content {
-            includeVersion("com.gradle", "develocity-gradle-plugin", "3.17-rc-1")
+            includeVersion("com.gradle", "develocity-gradle-plugin", "3.17-rc-2")
         }
     }
 }
@@ -36,7 +36,7 @@ dependencies {
     compatibilityApiCompileOnly(gradleApi())
 
     develocityCompatibilityCompileOnly(gradleApi())
-    develocityCompatibilityCompileOnly('com.gradle:develocity-gradle-plugin:3.17-rc-1')
+    develocityCompatibilityCompileOnly('com.gradle:develocity-gradle-plugin:3.17-rc-2')
     develocityCompatibilityImplementation(sourceSets.compatibilityApi.output)
 
     enterpriseCompatibilityCompileOnly(gradleApi())
@@ -131,7 +131,7 @@ testing {
                 implementation('org.junit.jupiter:junit-jupiter')
                 implementation('org.mockito:mockito-core:4.11.0')
                 implementation('org.mockito:mockito-junit-jupiter:4.11.0')
-                implementation('com.gradle:develocity-gradle-plugin:3.17-rc-1') {
+                implementation('com.gradle:develocity-gradle-plugin:3.17-rc-2') {
                     because("Verify that reflective proxies and adapters work with actual plugin classes")
                 }
             }

--- a/src/compatibilityApi/java/com/gradle/ccud/adapters/BuildScanAdapter.java
+++ b/src/compatibilityApi/java/com/gradle/ccud/adapters/BuildScanAdapter.java
@@ -21,15 +21,15 @@ public interface BuildScanAdapter {
 
     void buildScanPublished(Action<? super PublishedBuildScanAdapter> action);
 
-    void setTermsOfServiceUrl(String termsOfServiceUrl);
+    void setTermsOfUseUrl(String termsOfServiceUrl);
 
     @Nullable
-    String getTermsOfServiceUrl();
+    String getTermsOfUseUrl();
 
-    void setTermsOfServiceAgree(@Nullable String agree);
+    void setTermsOfUseAgree(@Nullable String agree);
 
     @Nullable
-    String getTermsOfServiceAgree();
+    String getTermsOfUseAgree();
 
     void setUploadInBackground(boolean uploadInBackground);
 

--- a/src/develocityCompatibility/java/com/gradle/ccud/adapters/develocity/BuildScanConfigurationAdapter.java
+++ b/src/develocityCompatibility/java/com/gradle/ccud/adapters/develocity/BuildScanConfigurationAdapter.java
@@ -71,25 +71,25 @@ class BuildScanConfigurationAdapter implements BuildScanAdapter {
     }
 
     @Override
-    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
-        buildScan.getTermsOfServiceUrl().set(termsOfServiceUrl);
+    public void setTermsOfUseUrl(String termsOfServiceUrl) {
+        buildScan.getTermsOfUseUrl().set(termsOfServiceUrl);
     }
 
     @Nullable
     @Override
-    public String getTermsOfServiceUrl() {
-        return buildScan.getTermsOfServiceUrl().getOrNull();
+    public String getTermsOfUseUrl() {
+        return buildScan.getTermsOfUseUrl().getOrNull();
     }
 
     @Override
-    public void setTermsOfServiceAgree(@Nullable String agree) {
-        buildScan.getTermsOfServiceAgree().set(agree);
+    public void setTermsOfUseAgree(@Nullable String agree) {
+        buildScan.getTermsOfUseAgree().set(agree);
     }
 
     @Nullable
     @Override
-    public String getTermsOfServiceAgree() {
-        return buildScan.getTermsOfServiceAgree().getOrNull();
+    public String getTermsOfUseAgree() {
+        return buildScan.getTermsOfUseAgree().getOrNull();
     }
 
     @Override

--- a/src/develocityCompatibilityTest/java/com/gradle/ccud/adapters/develocity/BuildScanConfigurationAdapterTest.java
+++ b/src/develocityCompatibilityTest/java/com/gradle/ccud/adapters/develocity/BuildScanConfigurationAdapterTest.java
@@ -94,14 +94,14 @@ public class BuildScanConfigurationAdapterTest {
         //given
         String value = "https://value.com";
         Property<String> prop = mockPropertyReturning(value);
-        when(configuration.getTermsOfServiceUrl()).thenReturn(prop);
+        when(configuration.getTermsOfUseUrl()).thenReturn(prop);
 
         // when
-        adapter.setTermsOfServiceUrl(value);
+        adapter.setTermsOfUseUrl(value);
 
         // then
         verify(prop).set(value);
-        assertEquals(value, adapter.getTermsOfServiceUrl());
+        assertEquals(value, adapter.getTermsOfUseUrl());
     }
 
     @Test
@@ -110,14 +110,14 @@ public class BuildScanConfigurationAdapterTest {
         //given
         String value = "no";
         Property<String> prop = mockPropertyReturning(value);
-        when(configuration.getTermsOfServiceAgree()).thenReturn(prop);
+        when(configuration.getTermsOfUseAgree()).thenReturn(prop);
 
         // when
-        adapter.setTermsOfServiceAgree(value);
+        adapter.setTermsOfUseAgree(value);
 
         // then
         verify(prop).set(value);
-        assertEquals(value, adapter.getTermsOfServiceAgree());
+        assertEquals(value, adapter.getTermsOfUseAgree());
     }
 
     @Test
@@ -147,18 +147,18 @@ public class BuildScanConfigurationAdapterTest {
         doExecuteActionWith(configuration).when(configuration).background(any());
 
         // and
-        when(configuration.getTermsOfServiceUrl()).thenReturn(mockProperty());
-        when(configuration.getTermsOfServiceAgree()).thenReturn(mockProperty());
+        when(configuration.getTermsOfUseUrl()).thenReturn(mockProperty());
+        when(configuration.getTermsOfUseAgree()).thenReturn(mockProperty());
 
         // when
         adapter.background(b -> {
-            b.setTermsOfServiceUrl("other url");
-            b.setTermsOfServiceAgree("no");
+            b.setTermsOfUseUrl("other url");
+            b.setTermsOfUseAgree("no");
         });
 
         // then
-        verify(configuration.getTermsOfServiceUrl()).set("other url");
-        verify(configuration.getTermsOfServiceAgree()).set("no");
+        verify(configuration.getTermsOfUseUrl()).set("other url");
+        verify(configuration.getTermsOfUseAgree()).set("no");
     }
 
     @Test

--- a/src/develocityCompatibilityTest/java/com/gradle/ccud/adapters/develocity/DevelocityConfigurationAdapterTest.java
+++ b/src/develocityCompatibilityTest/java/com/gradle/ccud/adapters/develocity/DevelocityConfigurationAdapterTest.java
@@ -111,18 +111,18 @@ class DevelocityConfigurationAdapterTest {
     void testBuildScanAction() {
         // given
         when(buildScan.getUploadInBackground()).thenReturn(mockProperty());
-        when(buildScan.getTermsOfServiceUrl()).thenReturn(mockProperty());
+        when(buildScan.getTermsOfUseUrl()).thenReturn(mockProperty());
 
 
         // when
         adapter.buildScan(buildScan -> {
             buildScan.setUploadInBackground(true);
-            buildScan.setTermsOfServiceUrl("server");
+            buildScan.setTermsOfUseUrl("server");
         });
 
         // then
         verify(buildScan.getUploadInBackground()).set(true);
-        verify(buildScan.getTermsOfServiceUrl()).set("server");
+        verify(buildScan.getTermsOfUseUrl()).set("server");
     }
 
 }

--- a/src/enterpriseCompatibility/java/com/gradle/ccud/adapters/enterprise/BuildScanExtensionAdapter.java
+++ b/src/enterpriseCompatibility/java/com/gradle/ccud/adapters/enterprise/BuildScanExtensionAdapter.java
@@ -72,24 +72,24 @@ class BuildScanExtensionAdapter implements BuildScanAdapter {
     }
 
     @Override
-    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+    public void setTermsOfUseUrl(String termsOfServiceUrl) {
         buildScan.setTermsOfServiceUrl(termsOfServiceUrl);
     }
 
     @Nullable
     @Override
-    public String getTermsOfServiceUrl() {
+    public String getTermsOfUseUrl() {
         return buildScan.getTermsOfServiceUrl();
     }
 
     @Override
-    public void setTermsOfServiceAgree(@Nullable String agree) {
+    public void setTermsOfUseAgree(@Nullable String agree) {
         buildScan.setTermsOfServiceAgree(agree);
     }
 
     @Nullable
     @Override
-    public String getTermsOfServiceAgree() {
+    public String getTermsOfUseAgree() {
         return buildScan.getTermsOfServiceAgree();
     }
 

--- a/src/enterpriseCompatibility/java/com/gradle/ccud/adapters/enterprise/BuildScanExtension_1_X_Adapter.java
+++ b/src/enterpriseCompatibility/java/com/gradle/ccud/adapters/enterprise/BuildScanExtension_1_X_Adapter.java
@@ -79,25 +79,25 @@ public class BuildScanExtension_1_X_Adapter implements DevelocityAdapter, BuildS
     }
 
     @Override
-    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+    public void setTermsOfUseUrl(String termsOfServiceUrl) {
         extension.setTermsOfServiceUrl(termsOfServiceUrl);
     }
 
     @Nullable
     @Override
-    public String getTermsOfServiceUrl() {
+    public String getTermsOfUseUrl() {
         warnAboutUnsupportedOperation("getTermsOfServiceUrl()");
         return null;
     }
 
     @Override
-    public void setTermsOfServiceAgree(@Nullable String agree) {
+    public void setTermsOfUseAgree(@Nullable String agree) {
         extension.setTermsOfServiceAgree(agree);
     }
 
     @Nullable
     @Override
-    public String getTermsOfServiceAgree() {
+    public String getTermsOfUseAgree() {
         warnAboutUnsupportedOperation("getTermsOfServiceAgree()");
         return null;
     }

--- a/src/enterpriseCompatibilityTest/java/com/gradle/ccud/adapters/enterprise/BuildScanExtensionAdapterTest.java
+++ b/src/enterpriseCompatibilityTest/java/com/gradle/ccud/adapters/enterprise/BuildScanExtensionAdapterTest.java
@@ -76,7 +76,7 @@ class BuildScanExtensionAdapterTest {
         String url = "https://terms-of-service.com";
 
         // when
-        adapter.setTermsOfServiceUrl(url);
+        adapter.setTermsOfUseUrl(url);
 
         // then
         verify(extension).setTermsOfServiceUrl(url);
@@ -85,7 +85,7 @@ class BuildScanExtensionAdapterTest {
         when(extension.getTermsOfServiceUrl()).thenReturn(url);
 
         // then
-        assertEquals(url, adapter.getTermsOfServiceUrl());
+        assertEquals(url, adapter.getTermsOfUseUrl());
     }
 
     @Test
@@ -95,7 +95,7 @@ class BuildScanExtensionAdapterTest {
         String agree = "yes";
 
         // when
-        adapter.setTermsOfServiceAgree(agree);
+        adapter.setTermsOfUseAgree(agree);
 
         // then
         verify(extension).setTermsOfServiceAgree(agree);
@@ -104,7 +104,7 @@ class BuildScanExtensionAdapterTest {
         when(extension.getTermsOfServiceAgree()).thenReturn(agree);
 
         // then
-        assertEquals(agree, adapter.getTermsOfServiceAgree());
+        assertEquals(agree, adapter.getTermsOfUseAgree());
     }
 
     @Test
@@ -148,7 +148,7 @@ class BuildScanExtensionAdapterTest {
         // when
         adapter.background(buildScan -> {
             buildScan.setUploadInBackground(true);
-            buildScan.setTermsOfServiceUrl("server");
+            buildScan.setTermsOfUseUrl("server");
         });
 
         // then

--- a/src/enterpriseCompatibilityTest/java/com/gradle/ccud/adapters/enterprise/BuildScanExtension_1_X_AdapterTest.java
+++ b/src/enterpriseCompatibilityTest/java/com/gradle/ccud/adapters/enterprise/BuildScanExtension_1_X_AdapterTest.java
@@ -139,13 +139,13 @@ public class BuildScanExtension_1_X_AdapterTest {
         String value = "https://value.com";
 
         // when
-        adapter.getBuildScan().setTermsOfServiceUrl(value);
+        adapter.getBuildScan().setTermsOfUseUrl(value);
 
         // then
         verify(extension).setTermsOfServiceUrl(value);
 
         // and
-        assertNull(adapter.getBuildScan().getTermsOfServiceUrl());
+        assertNull(adapter.getBuildScan().getTermsOfUseUrl());
     }
 
     @Test
@@ -155,11 +155,11 @@ public class BuildScanExtension_1_X_AdapterTest {
         String value = "yes";
 
         // when
-        adapter.getBuildScan().setTermsOfServiceAgree(value);
+        adapter.getBuildScan().setTermsOfUseAgree(value);
 
         // then
         verify(extension).setTermsOfServiceAgree(value);
-        assertNull(adapter.getBuildScan().getTermsOfServiceAgree());
+        assertNull(adapter.getBuildScan().getTermsOfUseAgree());
     }
 
     @Test
@@ -178,8 +178,8 @@ public class BuildScanExtension_1_X_AdapterTest {
     void testBuildScanAction() {
         // when
         adapter.buildScan(b -> {
-            b.setTermsOfServiceUrl("value");
-            b.setTermsOfServiceAgree("yes");
+            b.setTermsOfUseUrl("value");
+            b.setTermsOfUseAgree("yes");
         });
 
         // then
@@ -195,8 +195,8 @@ public class BuildScanExtension_1_X_AdapterTest {
 
         // when
         adapter.getBuildScan().background(b -> {
-            b.setTermsOfServiceUrl("value");
-            b.setTermsOfServiceAgree("yes");
+            b.setTermsOfUseUrl("value");
+            b.setTermsOfUseAgree("yes");
         });
 
         // then

--- a/src/enterpriseCompatibilityTest/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseExtensionAdapterTest.java
+++ b/src/enterpriseCompatibilityTest/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseExtensionAdapterTest.java
@@ -119,7 +119,7 @@ class GradleEnterpriseExtensionAdapterTest {
         // when
         adapter.buildScan(buildScan -> {
             buildScan.setUploadInBackground(true);
-            buildScan.setTermsOfServiceUrl("server");
+            buildScan.setTermsOfUseUrl("server");
         });
 
         // then


### PR DESCRIPTION
In RC2, the termsOfService APIs have been renamed to termsOfUse. This commit uses the new terminology in the adapter APIs + fixes compilation errors caused by the breaking changes in the RC