### PR TITLE
Ensure task configuration is lazy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,9 @@ java {
     }
 }
 
-jar.enabled = false
-shadowJar {
+tasks.named('jar') { enabled = false }
+
+tasks.named('shadowJar') {
     // required by the plugin-publish-plugin
     archiveClassifier = ''
 }
@@ -74,7 +75,7 @@ tasks.withType(ValidatePlugins).configureEach {
     enableStricterValidation = true
 }
 
-test {
+tasks.withType(Test).configureEach {
     useJUnitPlatform()
     dependsOn(shadowJar)
 }
@@ -118,7 +119,7 @@ tasks.named('githubRelease').configure {
     dependsOn(createReleaseTag)
 }
 
-tasks.withType(com.gradle.publish.PublishTask) {
+tasks.withType(com.gradle.publish.PublishTask).configureEach {
     notCompatibleWithConfigurationCache("$name task does not support configuration caching")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ tasks.withType(ValidatePlugins).configureEach {
 
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
-    dependsOn(shadowJar)
+    dependsOn(tasks.named('shadowJar'))
 }
 
 /*


### PR DESCRIPTION
This ensures no tasks are created eagerly in `build.gradle`. 
[Configuration build scan before](https://ge.solutions-team.gradle.com/s/rlwc3vn5y726w/performance/configuration?details=code-unit-build.gradle!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtYnVpbGQuZ3JhZGxlIl0)
[Configuration after build scan here](https://ge.solutions-team.gradle.com/s/u3yd5goebzl4q/performance/configuration?details=code-unit-build.gradle!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtY29tLmdyYWRsZS5wbHVnaW4tcHVibGlzaCIsImNvZGUtdW5pdC1idWlsZC5ncmFkbGUiXQ).