### PR TITLE
Fixed empty PR branch custom value

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -295,7 +295,7 @@ final class CustomBuildScanEnhancements {
                     addCustomValueAndSearchLink(develocity, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
                     addCustomValueAndSearchLink(develocity, "CI run", value));
-                envVariable("GITHUB_HEAD_REF", providers).ifPresent(value ->
+                envVariable("GITHUB_HEAD_REF", providers).filter(value -> !value.isEmpty()).ifPresent(value ->
                     buildScan.value("PR branch", value));
             }
 


### PR DESCRIPTION
Fixes issue https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/295.

Scans after the fix:
- with `export GITHUB_HEAD_REF=someBranch`: [scan](https://ge.solutions-team.gradle.com/s/aao45aos6qys6/custom-values#L6)
- with `export GITHUB_HEAD_REF= `: [scan](https://ge.solutions-team.gradle.com/s/q72quu37enkoq/custom-values)