### PR TITLE
NOTICE file is added and included in all assembled JAR files along with LICENSE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,13 @@ tasks.shadowJar {
     archiveClassifier = ""
 }
 
+tasks.withType<Jar>().configureEach {
+    into(".") {
+        from(layout.projectDirectory.file("LICENSE"))
+        from(layout.projectDirectory.dir("release/distribution"))
+    }
+}
+
 gradlePlugin {
     website = "https://github.com/gradle/common-custom-user-data-gradle-plugin"
     vcsUrl = "https://github.com/gradle/common-custom-user-data-gradle-plugin.git"

--- a/release/distribution/NOTICE
+++ b/release/distribution/NOTICE
@@ -1,0 +1,36 @@
+The following copyright statements and licenses apply to various third party open
+source software packages (or portions thereof) that are distributed with
+this content.
+
+TABLE OF CONTENTS
+=================
+
+The following is a listing of the open source components detailed in this
+document.  This list is provided for your convenience; please read further if
+you wish to review the copyright notice(s) and the full text of the license
+associated with each component.
+
+
+**SECTION 1: Apache License, V2.0**
+  * Develocity Gradle Plugin Adapters
+    * com.gradle:develocity-gradle-plugin-adapters
+
+SECTION 1: Apache License, V2.0
+================================
+
+Develocity Gradle Plugin Adapters
+-----------------------------------
+
+Copyright 2024 Gradle, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This PR adds a NOTICE file to the root of the project. The NOTICE file includes the licenses of all runtime dependencies, as can be seen in [this build scan](https://ge.solutions-team.gradle.com/s/rh6xon4ychuli/dependencies?toggled=W1swXSxbMCwyXV0).

Both the NOTICE and LICENSE files are then included in all assembled JAR files.