### PR TITLE
Use generic env var to detect CI

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
-val isCI = System.getenv("GITHUB_ACTIONS") != null
+val isCI = System.getenv("CI") != null
 
 develocity {
     server = "https://ge.solutions-team.gradle.com"


### PR DESCRIPTION
The CCUD build runs on both GitHub Actions and TeamCity. This change will correctly set the `isCI` var in both environments.