### PR TITLE
Add workflow for cross-version testing of current and past plugin versions

### DIFF
--- a/.github/workflows/compatibility-check-cross-version.yml
+++ b/.github/workflows/compatibility-check-cross-version.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       ccud-version:
+        description: The CCUD version to test. Leave blank to build and test CCUD from sources.
         required: false
         type: string
 
@@ -75,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
-        ge-plugin-version: ["3.18.2", "3.17.6", "3.16.2", "3.15.1", "3.14.1", "3.13.4", "3.12.6", "3.11.4", "3.10.3", "3.9", "3.8.1", "3.7.2", "3.6.4", "3.5.2", "3.4.1", "3.3.4", "3.2.1", "3.1.1", "3.0"]
+        ge-plugin-version: ["3.18.2", "3.17.6", "3.16.2", "3.15.1", "3.14.1", "3.13.4", "3.12.6", "3.11.4", "3.10.3", "3.9", "3.8.1", "3.7.2", "3.6.4", "3.5.2", "3.4.1", "3.3.4", "3.2.1"] ## Versions < 3.2.1 are unsupported ["3.1.1", "3.0"]
         gradle-version: [8, 5]
         include:
           - expect-failure: false
@@ -96,10 +97,11 @@ jobs:
       fail-fast: false
       matrix:
         ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
-        bs-plugin-version: ["2.4.2"] # All versions unsupported, just test one: "2.3", "2.2.1", "2.1", "2.0.2"]
+        bs-plugin-version: ["2.4.2"] # All versions unsupported, just test one: ["2.4.2", "2.3", "2.2.1", "2.1", "2.0.2"]
         gradle-version: [5]
         include:
-          - expect-failure: false
+          # Unsupported GE plugin versions with CCUD: "2.x"
+          - expect-failure: true
     uses: ./.github/workflows/compatibility-check-single-version.yml
     with:
       gradle-version: ${{ matrix.gradle-version }}
@@ -116,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
-        build-scan-plugin-version: ["1.16", "1.15.2", "1.14"] # Versions > 1.15 are unsupported: "1.13.4", "1.12.1", "1.11", "1.10.3", "1.9.1", "1.8"
+        build-scan-plugin-version: ["1.16", "1.15.2"] # Versions > 1.15 are unsupported: ["1.16", "1.15.2", "1.14", "1.13.4", "1.12.1", "1.11", "1.10.3", "1.9.1", "1.8"]
         gradle-version: [4]
         include:
           - expect-failure: false

--- a/.github/workflows/compatibility-check-cross-version.yml
+++ b/.github/workflows/compatibility-check-cross-version.yml
@@ -4,16 +4,58 @@ on:
   workflow_dispatch:
     inputs:
       ccud-version:
-        required: true
+        required: false
         type: string
-      
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      dev-ccud-version: ${{ steps.determine-current-version.outputs.ccud-version }}
+      test-ccud-version: ${{ steps.determine-test-version.outputs.ccud-version }}
+    steps:
+      - name: Checkout local repo
+        uses: actions/checkout@v4
+
+      - name: Read current CCUD version from release/version.txt
+        id: determine-current-version
+        run: 
+          echo "ccud-version=$(cat release/version.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Determine test CCUD version
+        id: determine-test-version
+        run: 
+          echo "ccud-version=${{ inputs.ccud-version || steps.determine-current-version.outputs.ccud-version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log current CCUD versions
+        run: |
+          echo "dev-ccud-version = ${{ steps.determine-current-version.outputs.ccud-version }}"
+          echo "test-ccud-version = ${{ steps.determine-test-version.outputs.ccud-version }}"
+
+      - name: Set up Java
+        if: ${{ steps.determine-current-version.outputs.ccud-version == steps.determine-test-version.outputs.ccud-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - name: Build CCUD plugin
+        if: ${{ steps.determine-current-version.outputs.ccud-version == steps.determine-test-version.outputs.ccud-version }}
+        run: ./gradlew publish
+
+      - name: Save plugin repository as artifact
+        if: ${{ steps.determine-current-version.outputs.ccud-version == steps.determine-test-version.outputs.ccud-version }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccud-plugin-repository
+          path: build/local-plugin-repository
+  
   dv-plugins:
+    needs: [ prepare ]
     strategy:
       fail-fast: false
       matrix:
-        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
         dv-plugin-version: ["3.18.2", "3.17.6"]
         gradle-version: [8, 5]
         include:
@@ -23,14 +65,16 @@ jobs:
       gradle-version: ${{ matrix.gradle-version }}
       apply-plugin-script: |
           find . -type f -name "*.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.develocity" version "${{ matrix.dv-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
+      build-ccud-plugin: ${{ matrix.ccud-plugin-version == needs.prepare.outputs.dev-ccud-version }}
       expect-failure: ${{ matrix.expect-failure }}
     secrets: inherit
 
   ge-3x-plugins:
+    needs: [ prepare ]
     strategy:
       fail-fast: false
       matrix:
-        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
         ge-plugin-version: ["3.18.2", "3.17.6", "3.16.2", "3.15.1", "3.14.1", "3.13.4", "3.12.6", "3.11.4", "3.10.3", "3.9", "3.8.1", "3.7.2", "3.6.4", "3.5.2", "3.4.1", "3.3.4", "3.2.1", "3.1.1", "3.0"]
         gradle-version: [8, 5]
         include:
@@ -42,15 +86,17 @@ jobs:
           find . -type f -name "settings.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.enterprise" version "${{ matrix.ge-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
           find . -type f -name "build.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.build-scan" version "${{ matrix.ge-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
           find . -type f -name "*.gradle" -exec sed -i '/develocity {/s/.*/gradleEnterprise {\n  buildScan { publishAlways() }/' {} +
+      build-ccud-plugin: ${{ matrix.ccud-plugin-version == needs.prepare.outputs.dev-ccud-version }}
       expect-failure: ${{ matrix.expect-failure }}
     secrets: inherit
 
   bs-2x-plugins:
+    needs: [ prepare ]
     strategy:
       fail-fast: false
       matrix:
-        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
-        bs-plugin-version: ["2.4.2", "2.3", "2.2.1", "2.1", "2.0.2"]
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
+        bs-plugin-version: ["2.4.2"] # All versions unsupported, just test one: "2.3", "2.2.1", "2.1", "2.0.2"]
         gradle-version: [5]
         include:
           - expect-failure: false
@@ -60,15 +106,17 @@ jobs:
       apply-plugin-script: |
           find . -type f -name "build.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.build-scan" version "${{ matrix.bs-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
           find . -type f -name "*.gradle" -exec sed -i '/develocity {/s/.*/gradleEnterprise {\n  buildScan { publishAlways() }/' {} +
+      build-ccud-plugin: ${{ matrix.ccud-plugin-version == needs.prepare.outputs.dev-ccud-version }}
       expect-failure: ${{ matrix.expect-failure }}
     secrets: inherit
 
   bs-1x-plugins:
+    needs: [ prepare ]
     strategy:
       fail-fast: false
       matrix:
-        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
-        build-scan-plugin-version: ["1.16", "1.15.2", "1.14", "1.13.4", "1.12.1", "1.11", "1.10.3", "1.9.1", "1.8"]
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', needs.prepare.outputs.test-ccud-version )) }}
+        build-scan-plugin-version: ["1.16", "1.15.2", "1.14"] # Versions > 1.15 are unsupported: "1.13.4", "1.12.1", "1.11", "1.10.3", "1.9.1", "1.8"
         gradle-version: [4]
         include:
           - expect-failure: false
@@ -78,5 +126,6 @@ jobs:
       apply-plugin-script: |
           find . -type f -name "build.gradle" -exec sed -i '/id "com.gradle.build-scan" version "1.16"/s/.*/id "com.gradle.build-scan" version "${{ matrix.build-scan-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
           find . -type f -name "build.gradle" -exec sed -i '/server = "https:\/\/ge.solutions-team.gradle.com"/s/.*/termsOfServiceUrl = "https:\/\/gradle.com\/terms-of-service"\ntermsOfServiceAgree = "yes"/' {} +
+      build-ccud-plugin: ${{ matrix.ccud-plugin-version == needs.prepare.outputs.dev-ccud-version }}
       expect-failure: ${{ matrix.expect-failure }}
     secrets: inherit

--- a/.github/workflows/compatibility-check-cross-version.yml
+++ b/.github/workflows/compatibility-check-cross-version.yml
@@ -1,0 +1,82 @@
+name: CCUD cross-version compatibility test
+
+on:
+  workflow_dispatch:
+    inputs:
+      ccud-version:
+        required: true
+        type: string
+      
+
+jobs:
+  dv-plugins:
+    strategy:
+      fail-fast: false
+      matrix:
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
+        dv-plugin-version: ["3.18.2", "3.17.6"]
+        gradle-version: [8, 5]
+        include:
+        - expect-failure: false
+    uses: ./.github/workflows/compatibility-check-single-version.yml
+    with:
+      gradle-version: ${{ matrix.gradle-version }}
+      apply-plugin-script: |
+          find . -type f -name "*.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.develocity" version "${{ matrix.dv-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
+      expect-failure: ${{ matrix.expect-failure }}
+    secrets: inherit
+
+  ge-3x-plugins:
+    strategy:
+      fail-fast: false
+      matrix:
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
+        ge-plugin-version: ["3.18.2", "3.17.6", "3.16.2", "3.15.1", "3.14.1", "3.13.4", "3.12.6", "3.11.4", "3.10.3", "3.9", "3.8.1", "3.7.2", "3.6.4", "3.5.2", "3.4.1", "3.3.4", "3.2.1", "3.1.1", "3.0"]
+        gradle-version: [8, 5]
+        include:
+          - expect-failure: false
+    uses: ./.github/workflows/compatibility-check-single-version.yml
+    with:
+      gradle-version: ${{ matrix.gradle-version }}
+      apply-plugin-script: |
+          find . -type f -name "settings.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.enterprise" version "${{ matrix.ge-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
+          find . -type f -name "build.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.build-scan" version "${{ matrix.ge-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
+          find . -type f -name "*.gradle" -exec sed -i '/develocity {/s/.*/gradleEnterprise {\n  buildScan { publishAlways() }/' {} +
+      expect-failure: ${{ matrix.expect-failure }}
+    secrets: inherit
+
+  bs-2x-plugins:
+    strategy:
+      fail-fast: false
+      matrix:
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
+        bs-plugin-version: ["2.4.2", "2.3", "2.2.1", "2.1", "2.0.2"]
+        gradle-version: [5]
+        include:
+          - expect-failure: false
+    uses: ./.github/workflows/compatibility-check-single-version.yml
+    with:
+      gradle-version: ${{ matrix.gradle-version }}
+      apply-plugin-script: |
+          find . -type f -name "build.gradle" -exec sed -i '/id "com.gradle.develocity" version "3.18.2"/s/.*/id "com.gradle.build-scan" version "${{ matrix.bs-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
+          find . -type f -name "*.gradle" -exec sed -i '/develocity {/s/.*/gradleEnterprise {\n  buildScan { publishAlways() }/' {} +
+      expect-failure: ${{ matrix.expect-failure }}
+    secrets: inherit
+
+  bs-1x-plugins:
+    strategy:
+      fail-fast: false
+      matrix:
+        ccud-plugin-version: ${{ fromJSON(format('[ ''{0}'' ]', inputs.ccud-version)) }}
+        build-scan-plugin-version: ["1.16", "1.15.2", "1.14", "1.13.4", "1.12.1", "1.11", "1.10.3", "1.9.1", "1.8"]
+        gradle-version: [4]
+        include:
+          - expect-failure: false
+    uses: ./.github/workflows/compatibility-check-single-version.yml
+    with:
+      gradle-version: ${{ matrix.gradle-version }}
+      apply-plugin-script: |
+          find . -type f -name "build.gradle" -exec sed -i '/id "com.gradle.build-scan" version "1.16"/s/.*/id "com.gradle.build-scan" version "${{ matrix.build-scan-plugin-version }}"\nid "com.gradle.common-custom-user-data-gradle-plugin" version "${{ matrix.ccud-plugin-version }}"/' {} +
+          find . -type f -name "build.gradle" -exec sed -i '/server = "https:\/\/ge.solutions-team.gradle.com"/s/.*/termsOfServiceUrl = "https:\/\/gradle.com\/terms-of-service"\ntermsOfServiceAgree = "yes"/' {} +
+      expect-failure: ${{ matrix.expect-failure }}
+    secrets: inherit

--- a/.github/workflows/compatibility-check-cross-version.yml
+++ b/.github/workflows/compatibility-check-cross-version.yml
@@ -1,4 +1,4 @@
-name: CCUD cross-version compatibility test
+name: Check cross-version compatibility
 
 on:
   workflow_dispatch:

--- a/.github/workflows/compatibility-check-single-version.yml
+++ b/.github/workflows/compatibility-check-single-version.yml
@@ -12,6 +12,9 @@ on:
       apply-plugin-script:
         required: true
         type: string
+      build-ccud-plugin:
+        required: true
+        type: boolean
       expect-failure:
         required: true
         type: boolean
@@ -32,6 +35,19 @@ jobs:
           sparse-checkout: 'sample-projects/gradle'
           path: 'dv-solutions'
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Download local CCUD plugin repository
+        if: ${{ inputs.build-ccud-plugin }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ccud-plugin-repository
+          path: build/local-plugin-repository
+
+      - name: Make local plugin repository available to samples
+        if: ${{ inputs.build-ccud-plugin }}
+        working-directory: dv-solutions/sample-projects/gradle
+        run: |
+          find . -type f -name "settings.gradle" -exec sed -i '1i pluginManagement {\n  repositories {\n    maven { url "${{ github.workspace }}/build/local-plugin-repository" }\n    gradlePluginPortal()\n  }\n}' {} +
 
       - name: Apply CCUD plugin to samples
         working-directory: dv-solutions/sample-projects/gradle

--- a/.github/workflows/compatibility-check-single-version.yml
+++ b/.github/workflows/compatibility-check-single-version.yml
@@ -1,4 +1,4 @@
-name: CCUD cross-version compatibility check for a single version
+name: Run single cross-version test
 description: |
   This reusable workflow tests compatibility of a single combination of CCUD plugin version, DV plugin version and Gradle version.
   The CCUD and DV versions are encoded in the 'apply-plugin-script' input.

--- a/.github/workflows/compatibility-check-single-version.yml
+++ b/.github/workflows/compatibility-check-single-version.yml
@@ -1,0 +1,68 @@
+name: CCUD cross-version compatibility check for a single version
+description: |
+  This reusable workflow tests compatibility of a single combination of CCUD plugin version, DV plugin version and Gradle version.
+  The CCUD and DV versions are encoded in the 'apply-plugin-script' input.
+
+on:
+  workflow_call:
+    inputs:
+      gradle-version:
+        required: true
+        type: string
+      apply-plugin-script:
+        required: true
+        type: string
+      expect-failure:
+        required: true
+        type: boolean
+    secrets:
+      BOT_GITHUB_TOKEN:
+        required: true
+      DEVELOCITY_ACCESS_KEY:
+        required: true
+
+jobs:
+  compatibility-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dv-solutions sample projects
+        uses: actions/checkout@v4
+        with:
+          repository: 'gradle/dv-solutions'
+          sparse-checkout: 'sample-projects/gradle'
+          path: 'dv-solutions'
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Apply CCUD plugin to samples
+        working-directory: dv-solutions/sample-projects/gradle
+        run: ${{ inputs.apply-plugin-script }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@main
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+      - name: Run Gradle
+        continue-on-error: ${{ inputs.expect-failure }}
+        id: gradle
+        working-directory: dv-solutions/sample-projects/gradle/${{ inputs.gradle-version }}.x/dv
+        run: ./gradlew build --stacktrace
+  
+      - name: Check Build Scan url
+        env:
+          BUILD_SCAN_URL: ${{ steps.gradle.outputs.build-scan-url }}
+        if: ${{ !inputs.expect-failure }}
+        shell: bash
+        run: |
+          if [ -z "$BUILD_SCAN_URL" ] ; then
+            echo "No Build Scan detected"
+            exit 1
+          else
+              echo "Got Build Scan URL: $BUILD_SCAN_URL"
+          fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ You may also remove `plugin-publish` and `signing` from the `plugins {}` block a
 
 signing {
     // Require publications to be signed on CI. Otherwise, publication will be signed only if keys are provided.
-    isRequired = providers.environmentVariable("CI").isPresent
+    isRequired = false // providers.environmentVariable("CI").isPresent
 
     useInMemoryPgpKeys(
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,
@@ -135,6 +135,12 @@ publishing {
                     url.set("https://github.com/gradle/common-custom-user-data-gradle-plugin")
                 }
             }
+        }
+    }
+    repositories {
+        maven {
+            name = "localPlugins"
+            url = uri("build/local-plugin-repository")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,8 +88,9 @@ You may also remove `plugin-publish` and `signing` from the `plugins {}` block a
  */
 
 signing {
-    // Require publications to be signed on CI. Otherwise, publication will be signed only if keys are provided.
-    isRequired = false // providers.environmentVariable("CI").isPresent
+    // Require publications to be signed for 'publishPlugins' on CI.
+    // Otherwise, publication will be signed only if keys are provided.
+    isRequired = gradle.taskGraph.hasTask("publishPlugins") && providers.environmentVariable("CI").isPresent
 
     useInMemoryPgpKeys(
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,
@@ -137,6 +138,7 @@ publishing {
             }
         }
     }
+    // Allow the plugin to be published to a local repository
     repositories {
         maven {
             name = "localPlugins"


### PR DESCRIPTION
This PR adds a new "Check cross-version compatibility" workflow that can be used to verify the compatibility of a selected CCUD Gradle Plugin with a range of Develocity, Gradle Enterprise and Build Scan plugins. 

At this stage, the only functionality that is tested is that, when the CCUD plugin is applied:
- The build succeeds
- A build scan can be published

No attempt is (yet) made to verify that CCUD features are working correctly.