### PR TITLE
Use new adapter for configuring Build Cache

### DIFF
--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -1,7 +1,9 @@
 package com.gradle;
 
+import com.gradle.develocity.agent.gradle.adapters.BuildCacheConfigurationAdapter;
 import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter;
 import com.gradle.develocity.agent.gradle.adapters.DevelocityAdapter;
+import com.gradle.develocity.agent.gradle.adapters.develocity.GradleBuildCacheConfigurationAdapter;
 import com.gradle.develocity.agent.gradle.adapters.develocity.DevelocityConfigurationAdapter;
 import com.gradle.develocity.agent.gradle.adapters.enterprise.BuildScanExtension_1_X_Adapter;
 import com.gradle.develocity.agent.gradle.adapters.enterprise.GradleEnterpriseExtensionAdapter;
@@ -71,14 +73,15 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         buildScanEnhancements.apply();
 
         BuildCacheConfiguration buildCache = settings.getBuildCache();
-        customDevelocityConfig.configureBuildCache(buildCache);
+        BuildCacheConfigurationAdapter buildCacheAdapter = new GradleBuildCacheConfigurationAdapter(buildCache);
+        customDevelocityConfig.configureBuildCache(buildCacheAdapter);
 
         // configuration changes applied in this block will override earlier configuration settings,
         // including those set in the settings.gradle(.kts)
         Action<Settings> settingsAction = __ -> {
             Overrides overrides = new Overrides(providers);
             overrides.configureDevelocity(develocity);
-            overrides.configureBuildCache(buildCache, develocity.getBuildCache());
+            overrides.configureBuildCache(buildCacheAdapter);
         };
 
         // it is possible that the settings have already been evaluated by now, in which case

--- a/src/main/java/com/gradle/CustomDevelocityConfig.java
+++ b/src/main/java/com/gradle/CustomDevelocityConfig.java
@@ -1,8 +1,8 @@
 package com.gradle;
 
+import com.gradle.develocity.agent.gradle.adapters.BuildCacheConfigurationAdapter;
 import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter;
 import com.gradle.develocity.agent.gradle.adapters.DevelocityAdapter;
-import org.gradle.caching.configuration.BuildCacheConfiguration;
 
 /**
  * Provide standardized Develocity configuration.
@@ -31,23 +31,19 @@ final class CustomDevelocityConfig {
         */
     }
 
-    void configureBuildCache(BuildCacheConfiguration buildCache) {
-        /* Example of build cache configuration
+    void configureBuildCache(BuildCacheConfigurationAdapter buildCache) {
 
+        /* Example of build cache configuration
         boolean isCiServer = System.getenv().containsKey("CI");
 
         // Enable the local build cache for all local and CI builds
         // For short-lived CI agents, it makes sense to disable the local build cache
-        buildCache.local(local -> {
-            local.setEnabled(true);
-        });
+        buildCache.getLocal().setEnabled(true);
 
         // Only permit store operations to the remote build cache for CI builds
         // Local builds will only read from the remote build cache
-        buildCache.remote(com.gradle.ccud.adapters.enterprise.proxies.GradleEnterpriseBuildCacheProxy.gradleEnterpriseBuildCacheClass() ,remote -> {
-            remote.setEnabled(true);
-            remote.setPush(isCiServer);
-        });
+        buildCache.getRemote().setEnabled(true);
+        buildCache.getRemote().setStoreEnabled(isCiServer);
 
         */
     }


### PR DESCRIPTION
The new `BuildCacheConfigurationAdapter` works with more DV plugin and Gradle versions, allowing CCUD plugin to be compatible with `com.gradle.enterprise` plugins back to v3.2.