### PR TITLE
Fixed getting git metadata when started from a different dir to the project

### DIFF
--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -69,7 +69,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
         BuildScanAdapter buildScan = develocity.getBuildScan();
         customDevelocityConfig.configureBuildScanPublishing(buildScan);
-        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, settings.getGradle(), settings.getRootDir().getAbsolutePath());
+        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, settings.getGradle(), settings.getRootDir());
         buildScanEnhancements.apply();
 
         BuildCacheConfiguration buildCache = settings.getBuildCache();
@@ -146,7 +146,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
         BuildScanAdapter buildScan = develocity.getBuildScan();
         customDevelocityConfig.configureBuildScanPublishing(buildScan);
-        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, project.getGradle(), project.getRootDir().getAbsolutePath());
+        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, project.getGradle(), project.getRootDir());
         buildScanEnhancements.apply();
 
         // Build cache configuration cannot be accessed from a project plugin

--- a/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -69,7 +69,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
         BuildScanAdapter buildScan = develocity.getBuildScan();
         customDevelocityConfig.configureBuildScanPublishing(buildScan);
-        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, settings.getGradle());
+        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, settings.getGradle(), settings.getRootDir().getAbsolutePath());
         buildScanEnhancements.apply();
 
         BuildCacheConfiguration buildCache = settings.getBuildCache();
@@ -146,7 +146,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
         BuildScanAdapter buildScan = develocity.getBuildScan();
         customDevelocityConfig.configureBuildScanPublishing(buildScan);
-        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, project.getGradle());
+        CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(develocity, providers, project.getGradle(), project.getRootDir().getAbsolutePath());
         buildScanEnhancements.apply();
 
         // Build cache configuration cannot be accessed from a project plugin

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -398,19 +398,19 @@ final class CustomBuildScanEnhancements {
 
     private void captureGitMetadata() {
         // Run expensive computation in background
-        buildScan.background(new CaptureGitMetadataAction(projectDir, providers, develocity));
+        buildScan.background(new CaptureGitMetadataAction(develocity, providers, projectDir));
     }
 
     private static final class CaptureGitMetadataAction implements Action<BuildScanAdapter> {
 
-        private final ProviderFactory providers;
         private final DevelocityAdapter develocity;
+        private final ProviderFactory providers;
         private final File projectDir;
 
-        private CaptureGitMetadataAction(File projectDir, ProviderFactory providers, DevelocityAdapter develocity) {
-            this.projectDir = projectDir;
-            this.providers = providers;
+        private CaptureGitMetadataAction(DevelocityAdapter develocity, ProviderFactory providers, File projectDir) {
             this.develocity = develocity;
+            this.providers = providers;
+            this.projectDir = projectDir;
         }
 
         @Override
@@ -419,11 +419,11 @@ final class CustomBuildScanEnhancements {
                 return;
             }
 
-             String gitRepo = execAndGetStdOut(projectDir, "git", "config", "--get", "remote.origin.url");
-             String gitCommitId = execAndGetStdOut(projectDir, "git", "rev-parse", "--verify", "HEAD");
-             String gitCommitShortId = execAndGetStdOut(projectDir, "git", "rev-parse", "--short=8", "--verify", "HEAD");
-             String gitBranchName = getGitBranchName(projectDir, () -> execAndGetStdOut(projectDir, "git", "rev-parse", "--abbrev-ref", "HEAD"));
-             String gitStatus = execAndGetStdOut(projectDir, "git", "status", "--porcelain");
+            String gitRepo = execAndGetStdOut(projectDir, "git", "config", "--get", "remote.origin.url");
+            String gitCommitId = execAndGetStdOut(projectDir, "git", "rev-parse", "--verify", "HEAD");
+            String gitCommitShortId = execAndGetStdOut(projectDir, "git", "rev-parse", "--short=8", "--verify", "HEAD");
+            String gitBranchName = getGitBranchName(projectDir, () -> execAndGetStdOut(projectDir, "git", "rev-parse", "--abbrev-ref", "HEAD"));
+            String gitStatus = execAndGetStdOut(projectDir, "git", "status", "--porcelain");
 
             if (isNotEmpty(gitRepo)) {
                 buildScan.value("Git repository", redactUserInfo(gitRepo));

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -8,6 +8,7 @@ import org.gradle.util.GradleVersion;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -140,11 +141,17 @@ public final class Utils {
         }
     }
 
-    static String execAndGetStdOut(String... args) {
+    /**
+     * Executes a command and returns the standard output as a string.
+     * @param dir the working directory of the subprocess, or null if the subprocess should inherit the working directory of the current process.
+     * @param args array containing the command to call and its arguments.
+     * @return the standard output of the command, or null if the command failed.
+     */
+    static String execAndGetStdOut(File dir, String... args) {
         Runtime runtime = Runtime.getRuntime();
         Process process;
         try {
-            process = runtime.exec(args);
+            process = runtime.exec(args, null, dir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Fixed getting git data when the gradle build is started from a different directory and given a path to the repository. This can happen if the build is started with the `-p` / `--project-dir` argument, or when using the [GradleConnector](https://docs.gradle.org/current/javadoc/org/gradle/tooling/GradleConnector.html) as the main entrypoint - which is what is used by the VSCode [gradle build server](https://devblogs.microsoft.com/java/new-build-server-for-gradle/), added by [gradle-java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle) VSCode extension.

To overcome this issue, I've added the `-C <root-project-path>` argument when running git commands, which will take care of such cases.

I will investigate and open similar PRs for other CCUD implementations if we want to add this, and this is approved.