### PR TITLE
Added setting CI Action and CI job id custom values on github action builds

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -306,6 +306,10 @@ final class CustomBuildScanEnhancements {
                     addCustomValueAndSearchLink(develocity, "CI run", value));
                 envVariable("GITHUB_HEAD_REF", providers).filter(value -> !value.isEmpty()).ifPresent(value ->
                     buildScan.value("PR branch", value));
+                envVariable("GITHUB_ACTION", providers).ifPresent(value ->
+                        addCustomValueAndSearchLink(develocity, "CI step id", value));
+                envVariable("GITHUB_JOB", providers).ifPresent(value ->
+                        addCustomValueAndSearchLink(develocity, "CI job id", value));
             }
 
             if (isGitLab(providers)) {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -304,12 +304,12 @@ final class CustomBuildScanEnhancements {
                     addCustomValueAndSearchLink(develocity, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
                     addCustomValueAndSearchLink(develocity, "CI run", value));
-                envVariable("GITHUB_HEAD_REF", providers).filter(value -> !value.isEmpty()).ifPresent(value ->
-                    buildScan.value("PR branch", value));
                 envVariable("GITHUB_ACTION", providers).ifPresent(value ->
-                        addCustomValueAndSearchLink(develocity, "CI step id", value));
+                        addCustomValueAndSearchLink(develocity, "CI step", value));
                 envVariable("GITHUB_JOB", providers).ifPresent(value ->
-                        addCustomValueAndSearchLink(develocity, "CI job id", value));
+                        addCustomValueAndSearchLink(develocity, "CI job", value));
+                envVariable("GITHUB_HEAD_REF", providers).filter(value -> !value.isEmpty()).ifPresent(value ->
+                        buildScan.value("PR branch", value));
             }
 
             if (isGitLab(providers)) {


### PR DESCRIPTION
Added setting CI Action and CI job id custom values on github action builds. [This](https://github.com/ribafish/reproducers/actions/runs/16146564695) is an example GHA builds (the `build` scan), with the [scan](https://ge.solutions-team.gradle.com/s/ykzv2537i72te) having two custom values (and search links) added: [CI job id](https://ge.solutions-team.gradle.com/s/ykzv2537i72te/custom-values#L0) and [CI step id](https://ge.solutions-team.gradle.com/s/ykzv2537i72te/custom-values#L3). This will be helpful when you've got multiple builds running consecutively and are passing in arguments that affect those builds, but are not captured in a build scan (best example are Maven profiles for CCUD Maven).

When this is accepted I will do the same for CCUD Maven (and sbt). 

Closes https://github.com/gradle/common-custom-user-data-gradle-plugin/issues/389.