### PR TITLE
Changed wrapper bot gh token from readonly to GH_BOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/wrapper-upgrade-execution.yml
+++ b/.github/workflows/wrapper-upgrade-execution.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Upgrade Wrappers
         run: ./gradlew clean upgradeGradleWrapperAll --continue -Porg.gradle.java.installations.auto-download=false
         env:
-          WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GH_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This allows PRs created by the wrapperbot to trigger workflows on the `pull_request` trigger. See [this](https://github.com/gradle/common-custom-user-data-gradle-plugin/actions/runs/16911881702) execution, which created [this PR](https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/421).