### PR TITLE
Capture run number & attempt for GitHub Actions builds

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -304,6 +304,10 @@ final class CustomBuildScanEnhancements {
                     addCustomValueAndSearchLink(develocity, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
                     addCustomValueAndSearchLink(develocity, "CI run", value));
+                envVariable("GITHUB_RUN_ATTEMPT", providers).ifPresent(value ->
+                        buildScan.value("CI run attempt", value));
+                envVariable("GITHUB_RUN_NUMBER", providers).ifPresent(value ->
+                        buildScan.value("CI run number", value));
                 envVariable("GITHUB_ACTION", providers).ifPresent(value ->
                         addCustomValueAndSearchLink(develocity, "CI step", value));
                 envVariable("GITHUB_JOB", providers).ifPresent(value ->

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -294,26 +294,47 @@ final class CustomBuildScanEnhancements {
 
             if (isGitHubActions(providers)) {
                 buildScan.value("CI provider", "GitHub Actions");
-                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL", providers);
+
+                Optional<String> workflow = envVariable("GITHUB_WORKFLOW", providers);
+                Optional<String> jobId = envVariable("GITHUB_JOB", providers);
+                Optional<String> actionNameOrStepId = envVariable("GITHUB_ACTION", providers);
+                Optional<String> runId = envVariable("GITHUB_RUN_ID", providers);
+                Optional<String> runAttempt = envVariable("GITHUB_RUN_ATTEMPT", providers);
+                Optional<String> runNumber = envVariable("GITHUB_RUN_NUMBER", providers);
+                Optional<String> headRef = envVariable("GITHUB_HEAD_REF", providers).filter(value -> !value.isEmpty());
+                Optional<String> serverUrl = envVariable("GITHUB_SERVER_URL", providers);
                 Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY", providers);
-                Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID", providers);
-                if (gitHubUrl.isPresent() && gitRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", gitHubUrl.get() + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
-                }
-                envVariable("GITHUB_WORKFLOW", providers).ifPresent(value ->
-                    addCustomValueAndSearchLink(develocity, "CI workflow", value));
-                envVariable("GITHUB_RUN_ID", providers).ifPresent(value ->
-                    addCustomValueAndSearchLink(develocity, "CI run", value));
-                envVariable("GITHUB_RUN_ATTEMPT", providers).ifPresent(value ->
-                        buildScan.value("CI run attempt", value));
-                envVariable("GITHUB_RUN_NUMBER", providers).ifPresent(value ->
-                        buildScan.value("CI run number", value));
-                envVariable("GITHUB_ACTION", providers).ifPresent(value ->
-                        addCustomValueAndSearchLink(develocity, "CI step", value));
-                envVariable("GITHUB_JOB", providers).ifPresent(value ->
+
+                workflow.ifPresent(value ->
+                        addCustomValueAndSearchLink(develocity, "CI workflow", value));
+                jobId.ifPresent(value ->
                         addCustomValueAndSearchLink(develocity, "CI job", value));
-                envVariable("GITHUB_HEAD_REF", providers).filter(value -> !value.isEmpty()).ifPresent(value ->
+                actionNameOrStepId.ifPresent(value ->
+                        addCustomValueAndSearchLink(develocity, "CI step", value));
+
+                runId.ifPresent(value ->
+                        buildScan.value("CI run", value));
+                runAttempt.ifPresent(value ->
+                        buildScan.value("CI run attempt", value));
+                runNumber.ifPresent(value ->
+                        buildScan.value("CI run number", value));
+                headRef.ifPresent(value ->
                         buildScan.value("PR branch", value));
+
+                if (serverUrl.isPresent() && gitRepository.isPresent() && runId.isPresent()) {
+                    StringBuilder githubActionsBuild = new StringBuilder(serverUrl.get())
+                            .append("/").append(gitRepository.get())
+                            .append("/actions/runs/").append(runId.get());
+                    runAttempt.ifPresent(value -> githubActionsBuild.append("/attempts/").append(value));
+                    buildScan.link("GitHub Actions build", githubActionsBuild.toString());
+                }
+
+                if (runId.isPresent()) {
+                    Map<String, String> params = new HashMap<>();
+                    params.put("CI run", runId.get());
+                    runAttempt.ifPresent(value -> params.put("CI run attempt", value));
+                    addSearchLink(develocity, "CI run", params);
+                }
             }
 
             if (isGitLab(providers)) {


### PR DESCRIPTION
This PR adds capturing of run number & attempt for GitHub Actions builds. The following values have been added:

- `CI run attempt` – The value of [`GITHUB_RUN_ATTEMPT`](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#:~:text=example%2C%2090.-,GITHUB_RUN_ATTEMPT,-A%20unique%20number)  if present
- `CI run number` – The value of [`GITHUB_RUN_NUMBER`](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#:~:text=example%2C%201658821493.-,GITHUB_RUN_NUMBER,-A%20unique%20number) if present

In addition, the following links have been updated:

- `GitHub Actions build` – If `GITHUB_RUN_ATTEMPT` is present, the attempt will be included in the path of the URL
- `CI run build scans` –  If `GITHUB_RUN_ATTEMPT` is present, the attempt will be included in the build scan custom value filter

Example Build Scans:
- 1st attempt: https://ge.solutions-team.gradle.com/s/jjyvg3iohwi3c
- 2nd attempt: https://ge.solutions-team.gradle.com/s/q237jupx6auri
- 3rd attempt: https://ge.solutions-team.gradle.com/s/aqie5nenjhncc

Once this is approved & merged, I'll do the same for Maven and sbt.