### PR TITLE
Add AGENTS.md and CLAUDE.md for release hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,4 @@
-# Agent guidelines
-
-This file captures guidance for agents (and humans) contributing to this repository. It is intentionally narrow: its goal is to catch two things that are routinely missed during feature development — versioning and changelog entries — not to serve as a comprehensive contributor guide.
-
-## Versioning
+# Versioning
 
 - This plugin follows [Semantic Versioning](https://semver.org/).
 - The authoritative version lives in [`release/version.txt`](release/version.txt).
@@ -14,7 +10,7 @@ This file captures guidance for agents (and humans) contributing to this reposit
   - **Major** (e.g. `2.6.0` → `3.0.0`) — breaking changes to public behavior or consumer configuration.
 - If `release/version.txt` already reflects the required bump relative to the released version, leave it. Only raise it further if your change warrants a larger bump than what is already staged.
 
-## Changelog
+# Changelog
 
 - Every user-visible change must add an entry to [`release/changes.md`](release/changes.md) in the **same PR** that introduces the change. The contents of this file become the body of the GitHub release verbatim.
 - Format: a flat markdown bullet list, one line per change, each line tagged.
@@ -24,14 +20,18 @@ This file captures guidance for agents (and humans) contributing to this reposit
   - `[IMPROVEMENT]` — an enhancement to existing behavior that is not a bug fix and not a wholly new feature.
 - Use backticks around identifiers, tag names, value keys, environment variables, and branch-like strings.
 - Examples from recent releases:
-  - `` - [FIX] Rename `AI Agent` tag to `AI` ``
-  - `` - [NEW] For GitHub PRs, capture `GITHUB_BASE_REF` as the value `PR base branch` ``
-  - `- [NEW] Capture GitHub Actions run number and run attempt as custom values to precisely identify workflow runs`
+
+  ```markdown
+  - [FIX] Rename `AI Agent` tag to `AI`
+  - [NEW] For GitHub PRs, capture `GITHUB_BASE_REF` as the value `PR base branch`
+  - [NEW] Capture GitHub Actions run number and run attempt as custom values to precisely identify workflow runs
+  ```
+
 - After a release, the post-release workflow resets `release/changes.md` to `- [NEW] TBD`. Replace that placeholder on your first substantive change rather than appending below it.
 
-## Exceptions
+# Versioning and changelog exceptions
 
-The rules above target user-visible changes. They do **not** apply to:
+The versioning and changelog rules above target user-visible changes. They do **not** apply to:
 
 - Routine dependency updates (e.g. Renovate minor/patch bumps of build plugins, GitHub Actions, or transitive libraries) that do not alter plugin behavior for consumers. These may merge without a version bump or changelog entry.
 - Anything else that is strictly internal and invisible to plugin consumers (CI configuration, repo tooling, internal docs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent guidelines
+
+This file captures guidance for agents (and humans) contributing to this repository. It is intentionally narrow: its goal is to catch two things that are routinely missed during feature development — versioning and changelog entries — not to serve as a comprehensive contributor guide.
+
+## Versioning
+
+- This plugin follows [Semantic Versioning](https://semver.org/).
+- The authoritative version lives in [`release/version.txt`](release/version.txt).
+- **Any user-visible change must come with a version bump in the same PR.**
+- Decide the correct bump by comparing against the **currently released version** — the latest [GitHub release](https://github.com/gradle/common-custom-user-data-gradle-plugin/releases) / plugin portal version — not the value currently in `release/version.txt`. That file may already be ahead of the last release because a post-release workflow pre-bumps it to the next patch.
+- Choose:
+  - **Patch** (e.g. `2.6.0` → `2.6.1`) — bug fixes only.
+  - **Minor** (e.g. `2.6.0` → `2.7.0`) — new user-visible features, newly captured values/tags, new configuration options, or user-visible improvements.
+  - **Major** (e.g. `2.6.0` → `3.0.0`) — breaking changes to public behavior or consumer configuration.
+- If `release/version.txt` already reflects the required bump relative to the released version, leave it. Only raise it further if your change warrants a larger bump than what is already staged.
+
+## Changelog
+
+- Every user-visible change must add an entry to [`release/changes.md`](release/changes.md) in the **same PR** that introduces the change. The contents of this file become the body of the GitHub release verbatim.
+- Format: a flat markdown bullet list, one line per change, each line tagged.
+- Tags:
+  - `[NEW]` — a new feature or newly captured data.
+  - `[FIX]` — a bug fix or corrected behavior (including renames or cleanups that users will observe).
+  - `[IMPROVEMENT]` — an enhancement to existing behavior that is not a bug fix and not a wholly new feature.
+- Use backticks around identifiers, tag names, value keys, environment variables, and branch-like strings.
+- Examples from recent releases:
+  - `` - [FIX] Rename `AI Agent` tag to `AI` ``
+  - `` - [NEW] For GitHub PRs, capture `GITHUB_BASE_REF` as the value `PR base branch` ``
+  - `- [NEW] Capture GitHub Actions run number and run attempt as custom values to precisely identify workflow runs`
+- After a release, the post-release workflow resets `release/changes.md` to `- [NEW] TBD`. Replace that placeholder on your first substantive change rather than appending below it.
+
+## Exceptions
+
+The rules above target user-visible changes. They do **not** apply to:
+
+- Routine dependency updates (e.g. Renovate minor/patch bumps of build plugins, GitHub Actions, or transitive libraries) that do not alter plugin behavior for consumers. These may merge without a version bump or changelog entry.
+- Anything else that is strictly internal and invisible to plugin consumers (CI configuration, repo tooling, internal docs).
+
+When a dependency update does change consumer-visible behavior (for example, a bumped compile-time dependency that alters captured data, changes a public API, or fixes a user-facing bug), treat it as a normal change and follow the versioning and changelog rules above. Treat borderline cases as exceptions to discuss in review rather than trying to generalize them here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+Contributor guidance for all agents — including Claude Code — lives in [AGENTS.md](AGENTS.md).
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` and `CLAUDE.md` at the repo root documenting the two steps that most commonly get missed when a change lands in this repo:

1. Bumping `release/version.txt` per semantic versioning, decided against the **currently released** version (not whatever happens to be in `version.txt`, which is pre-bumped to the next patch after every release).
2. Adding an entry to `release/changes.md` in the same PR, using the `[NEW]` / `[FIX]` / `[IMPROVEMENT]` tag format already established in the file's history.

`CLAUDE.md` delegates to `AGENTS.md` via the `@AGENTS.md` directive so Claude Code picks up the same guidance transitively.

The guidance explicitly carves out routine dependency updates (e.g. Renovate minor/patch bumps) so that those continue to merge without triggering either rule.

## Why this is narrow on purpose

The goal of this PR is **not** to produce a comprehensive contributor guide. It is to catch two items that repeatedly slip through — version and changelog — and nothing more. A broader AGENTS.md can grow later as we find more gaps worth codifying.

## Structure

This PR intentionally puts all of this into the AGENTS.md file, rather than creating other smaller documents. Both rules apply to *every* meaningful change an agent makes in this repo. Splitting them would add indirection (and more file reads) without reducing the context that's actually relevant at the moment of change.

## Rollout

Once this is approved, I plan to apply the same pair of files to the other relevant solutions-team repos that follow the same `release/version.txt` + `release/changes.md` convention.