### PR TITLE
Set up Artifact + Setup Cache

### DIFF
--- a/.github/actions/setup-and-restore-artifact-cache/action.yml
+++ b/.github/actions/setup-and-restore-artifact-cache/action.yml
@@ -29,13 +29,14 @@ runs:
         fi
 
         CMD="${{ env[format('JAVA_HOME_21_{0}', runner.arch)] }}/bin/java -jar $JAR_PATH"
-        echo "ARTIFACT_CACHE_CMD=$CMD" >> $GITHUB_ENV
+        echo "ARTIFACT_CACHE_CMD=$CMD" >> "$GITHUB_ENV"
 
         CMD_OPTS="--dv-server=$DV_SERVER ${ARTIFACT_CACHE_IMAGE:+--image-name=$ARTIFACT_CACHE_IMAGE} $ARTIFACT_CACHE_OPTS"
-        echo "ARTIFACT_CACHE_CMD_OPTS=$CMD_OPTS" >> $GITHUB_ENV
+        echo "ARTIFACT_CACHE_CMD_OPTS=$CMD_OPTS" >> "$GITHUB_ENV"
 
     - name: Restore from Artifact Cache
       id: restore_cache
+      continue-on-error: true
       shell: bash
       run: $ARTIFACT_CACHE_CMD restore $ARTIFACT_CACHE_CMD_OPTS
 

--- a/.github/actions/setup-and-restore-artifact-cache/action.yml
+++ b/.github/actions/setup-and-restore-artifact-cache/action.yml
@@ -1,0 +1,45 @@
+name: 'Setup and Restore Artifact Cache'
+description: 'Provisions Artifact Cache CLI and restores from cache'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Provision and configure Artifact Cache
+      shell: bash
+      run: |
+        TOOL_DIR="${{ runner.tool_cache }}/develocity/artifact-cache/${{ env.ARTIFACT_CACHE_CLI_VERSION }}"
+        JAR_PATH="$TOOL_DIR/${{ env.ARTIFACT_CACHE_CLI_FILENAME }}.jar"
+        mkdir -p "$TOOL_DIR"
+
+        # Download if not present
+        if [ ! -f "$JAR_PATH" ]; then
+        echo "Downloading Artifact Cache CLI v${{ env.ARTIFACT_CACHE_CLI_VERSION }}..."
+        curl --location --fail --silent --show-error \
+         --connect-timeout 5 --max-time 30 \
+         --retry 3 --retry-delay 3 --retry-max-time 60 \
+         "https://docs.gradle.com/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar" \
+         --output "$JAR_PATH"
+
+        # Verify SHA-256 checksum
+        curl --location --fail --silent --show-error \
+         "https://docs.gradle.com/downloads/develocity-artifact-cache-cli/develocity-artifact-cache-cli-${{ env.ARTIFACT_CACHE_CLI_VERSION }}.jar.sha256" \
+         --output "$JAR_PATH.sha256"
+        echo "$(cat "$JAR_PATH.sha256") $JAR_PATH" | sha256sum --check
+        rm "$JAR_PATH.sha256"
+        fi
+
+        CMD="${{ env[format('JAVA_HOME_21_{0}', runner.arch)] }}/bin/java -jar $JAR_PATH"
+        echo "ARTIFACT_CACHE_CMD=$CMD" >> $GITHUB_ENV
+
+        CMD_OPTS="--dv-server=$DV_SERVER ${ARTIFACT_CACHE_IMAGE:+--image-name=$ARTIFACT_CACHE_IMAGE} $ARTIFACT_CACHE_OPTS"
+        echo "ARTIFACT_CACHE_CMD_OPTS=$CMD_OPTS" >> $GITHUB_ENV
+
+    - name: Restore from Artifact Cache
+      id: restore_cache
+      shell: bash
+      run: $ARTIFACT_CACHE_CMD restore $ARTIFACT_CACHE_CMD_OPTS
+
+    - name: Warn on Cache Restore Failure
+      if: steps.restore_cache.outcome == 'failure'
+      shell: bash
+      run: 'echo "WARNING: Could not restore the Artifact Cache. The build will proceed but may be slower."'

--- a/.github/actions/store-artifact-cache/action.yml
+++ b/.github/actions/store-artifact-cache/action.yml
@@ -1,0 +1,29 @@
+name: 'Store Artifact Cache'
+description: 'Stores to Artifact Cache'
+
+inputs:
+  artifact-name:
+    description: 'Name for the uploaded artifact'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Store to Artifact Cache
+      if: success()
+      id: store_cache
+      continue-on-error: true
+      shell: bash
+      run: $ARTIFACT_CACHE_CMD store $ARTIFACT_CACHE_CMD_OPTS
+
+    - name: Warn on Cache Store Failure
+      if: steps.store_cache.outcome == 'failure'
+      shell: bash
+      run: 'echo "WARNING: Failed to store in the Artifact Cache."'
+
+    - name: Persist Artifact Cache Logs
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: '~/.develocity/artifact-cache/artifact-cache.log'
+        retention-days: 7

--- a/.github/workflows/build-verification-nightly.yml
+++ b/.github/workflows/build-verification-nightly.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 env:
   # Artifact Cache CLI Configuration
-  ARTIFACT_CACHE_CLI_VERSION: 1.1.0
+  ARTIFACT_CACHE_CLI_VERSION: 1.2.0
 
   ## Develocity
   DV_SERVER: https://ge.solutions-team.gradle.com

--- a/.github/workflows/build-verification-nightly.yml
+++ b/.github/workflows/build-verification-nightly.yml
@@ -133,7 +133,7 @@ jobs:
         uses: ./.github/actions/store-artifact-cache
         if: env.ARTIFACT_CACHE_STORE == 'true'
         with:
-          artifact-name: artifact-cache-${{ github.job }}.log
+          artifact-name: artifact-cache-${{ github.job }}-${{ matrix.gradle-version }}.log
 
   failure-notification:
     name: Matrix failure notification

--- a/.github/workflows/build-verification-nightly.yml
+++ b/.github/workflows/build-verification-nightly.yml
@@ -20,7 +20,7 @@ env:
   ## Misc
   ARTIFACT_CACHE_CLI_FILENAME: develocity-artifact-cache-cli
   ARTIFACT_CACHE_OPTS: "--gradle-home=/home/runner/.gradle"
-  ARTIFACT_CACHE_STORE: true
+  ARTIFACT_CACHE_STORE: "true"
 
 jobs:
   verification:

--- a/.github/workflows/build-verification-nightly.yml
+++ b/.github/workflows/build-verification-nightly.yml
@@ -9,6 +9,18 @@ on:
     paths:
       - ".github/workflows/build-verification-nightly.yml"
   workflow_dispatch:
+env:
+  # Artifact Cache CLI Configuration
+  ARTIFACT_CACHE_CLI_VERSION: 1.1.0
+
+  ## Develocity
+  DV_SERVER: https://ge.solutions-team.gradle.com
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
+
+  ## Misc
+  ARTIFACT_CACHE_CLI_FILENAME: develocity-artifact-cache-cli
+  ARTIFACT_CACHE_OPTS: "--gradle-home=/home/runner/.gradle"
+  ARTIFACT_CACHE_STORE: true
 
 jobs:
   verification:
@@ -25,12 +37,20 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
+          cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: 'release-candidate'
+      - name: Setup and restore Universal Cache
+        uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Build and publish to Maven Local with Gradle
         run: gradle build publishToMavenLocal -x signPluginMavenPublication -i -Porg.gradle.java.installations.auto-download=false
         env:
           DISABLE_REQUIRED_SIGNING: true
+      - name: Store Universal Cache
+        uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
+        with:
+          artifact-name: artifact-cache-${{ github.job }}.log
       - name: Upload published plugin
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -57,8 +77,11 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
+          cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
+      - name: Setup and restore Universal Cache
+        uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Download plugin to maven local
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -106,6 +129,11 @@ jobs:
       - name: Run a build with the locally published plugin
         run: gradle help "-Dscan.value.gradle-version=${{ matrix.gradle-version }}" "-Dscan.value.java-version=${{ matrix.java-version }}"
         working-directory: ${{ runner.temp }}
+      - name: Store Universal Cache
+        uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
+        with:
+          artifact-name: artifact-cache-${{ github.job }}.log
 
   failure-notification:
     name: Matrix failure notification

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -69,12 +69,16 @@ jobs:
             java-version: '8'
           - gradle-version: '8.0'
             java-version: '8'
+          # universal-cache requires Gradle 8.1+
           - gradle-version: '9.0.0'
             java-version: '21'
+            universal-cache: true
           - gradle-version: 'current'
             java-version: '21'
+            universal-cache: true
           - gradle-version: 'release-candidate'
             java-version: '21'
+            universal-cache: true
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -90,6 +94,7 @@ jobs:
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
       - name: Setup and restore Universal Cache
+        if: matrix.universal-cache
         uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Download plugin to maven local
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -178,6 +183,6 @@ jobs:
         working-directory: ${{ runner.temp }}
       - name: Store Universal Cache
         uses: ./.github/actions/store-artifact-cache
-        if: env.ARTIFACT_CACHE_STORE == 'true'
+        if: matrix.universal-cache && env.ARTIFACT_CACHE_STORE == 'true'
         with:
-          artifact-name: artifact-cache-${{ github.job }}.log
+          artifact-name: artifact-cache-${{ github.job }}-${{ matrix.gradle-version }}.log

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -4,14 +4,14 @@ permissions:
 on: [ push, pull_request, workflow_dispatch ]
 
 env:
-  # Artifact Cache Configuration
+  # Artifact Cache CLI Configuration
   ARTIFACT_CACHE_CLI_VERSION: 1.1.0
 
-  # Develocity
+  ## Develocity
   DV_SERVER: https://ge.solutions-team.gradle.com
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
 
-  # Misc
+  ## Misc
   ARTIFACT_CACHE_CLI_FILENAME: develocity-artifact-cache-cli
   ARTIFACT_CACHE_OPTS: "--gradle-home=/home/runner/.gradle"
   ARTIFACT_CACHE_STORE: true
@@ -34,7 +34,7 @@ jobs:
         with:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-      - name: Setup and restore Artifact Cache
+      - name: Setup and restore Universal Cache
         uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Build and publish to Maven Local with Gradle
         run: ./gradlew build publishToMavenLocal -x signPluginMavenPublication -i -Porg.gradle.java.installations.auto-download=false
@@ -45,7 +45,7 @@ jobs:
         with:
           name: common-custom-user-data-gradle-plugin
           path: ~/.m2/repository/com/gradle
-      - name: Store Artifact Cache
+      - name: Store Universal Cache
         uses: ./.github/actions/store-artifact-cache
         if: env.ARTIFACT_CACHE_STORE == 'true'
         with:
@@ -89,6 +89,8 @@ jobs:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
+      - name: Setup and restore Universal Cache
+        uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Download plugin to maven local
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -174,3 +176,8 @@ jobs:
         id: build-with-local-plugin
         run: gradle help "-Dscan.value.gradle-version=${{ matrix.gradle-version }}" "-Dscan.value.java-version=${{ matrix.java-version }}"
         working-directory: ${{ runner.temp }}
+      - name: Store Universal Cache
+        uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
+        with:
+          artifact-name: artifact-cache-${{ github.job }}.log

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request, workflow_dispatch ]
 
 env:
   # Artifact Cache CLI Configuration
-  ARTIFACT_CACHE_CLI_VERSION: 1.1.0
+  ARTIFACT_CACHE_CLI_VERSION: 1.2.0
 
   ## Develocity
   DV_SERVER: https://ge.solutions-team.gradle.com

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -3,6 +3,20 @@ permissions:
   contents: read
 on: [ push, pull_request, workflow_dispatch ]
 
+env:
+  # Artifact Cache Configuration
+  ARTIFACT_CACHE_CLI_VERSION: 1.1.0
+
+  # Develocity
+  DV_SERVER: https://ge.solutions-team.gradle.com
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
+
+  # Misc
+  ARTIFACT_CACHE_CLI_FILENAME: develocity-artifact-cache-cli
+  ARTIFACT_CACHE_OPTS: "--gradle-home=/home/runner/.gradle"
+  ARTIFACT_CACHE_STORE: true
+
+
 jobs:
   verification:
     name: Verification
@@ -18,7 +32,10 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
+          cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
+      - name: Setup and restore Artifact Cache
+        uses: ./.github/actions/setup-and-restore-artifact-cache
       - name: Build and publish to Maven Local with Gradle
         run: ./gradlew build publishToMavenLocal -x signPluginMavenPublication -i -Porg.gradle.java.installations.auto-download=false
         env:
@@ -28,6 +45,11 @@ jobs:
         with:
           name: common-custom-user-data-gradle-plugin
           path: ~/.m2/repository/com/gradle
+      - name: Store Artifact Cache
+        uses: ./.github/actions/store-artifact-cache
+        if: env.ARTIFACT_CACHE_STORE == 'true'
+        with:
+          artifact-name: artifact-cache-${{ github.job }}.log
 
   local-test:
     name: Test with Locally Published Plugin
@@ -64,6 +86,7 @@ jobs:
       - name: Set up Gradle ${{ matrix.gradle-version }}
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
+          cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
       - name: Download plugin to maven local

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -14,7 +14,7 @@ env:
   ## Misc
   ARTIFACT_CACHE_CLI_FILENAME: develocity-artifact-cache-cli
   ARTIFACT_CACHE_OPTS: "--gradle-home=/home/runner/.gradle"
-  ARTIFACT_CACHE_STORE: true
+  ARTIFACT_CACHE_STORE: "true"
 
 
 jobs:


### PR DESCRIPTION
Adds Develocity Universal Cache (Artifact Cache + Setup Cache) to the build verification workflows:

- New composite actions `setup-and-restore-artifact-cache` and `store-artifact-cache` (CLI v1.1.0, checksum-verified download, cached in the runner tool cache)
- Wired into `build-verification.yml` and `build-verification-nightly.yml` around the build steps, with `gradle/actions` caching disabled in favor of the Universal Cache
- Cache logs persisted as workflow artifacts (7-day retention)

## Results: Empty Cache vs Full Cache Hit

Measured on the `Verify Build` workflow, `Verification` job, step `Build and publish to Maven Local with Gradle` (`gradle build publishToMavenLocal`) — [run 26876254961](https://github.com/gradle/common-custom-user-data-gradle-plugin/actions/runs/26876254961), attempt 1 (empty cache) vs attempt 2 (full cache hit).

| Metric | Empty Cache | Full Cache Hit | Delta |
|---|---|---|---|
| Build scan | [7rg6ojumdx6w4](https://ge.solutions-team.gradle.com/s/7rg6ojumdx6w4) | [bokdkd2uwgvmm](https://ge.solutions-team.gradle.com/s/bokdkd2uwgvmm) | |
| Overall build duration | 53.3 s | 18.9 s | **−64.6%** |
| Configuration phase | 36.0 s | 8.4 s | **−76.7%** |
| Network downloads | 137 files / 34.2 MiB | 0 files / 0 B | **−100%** |
| Setup Cache restore | 0 (image not found) | 20 artifacts / 35.1 MiB in 7.4 s | |
| Artifact Cache restore | 0 entries | 75 entries / 161 MiB in 12.6 s wall-clock | |
| Cache store step | 2.9 s / 9.9 MiB uploaded (seeding) | 0.6 s / 98.7 KiB uploaded | |

With a warm Universal Cache, the build runs fully offline (0 network requests vs 137) and finishes 34.4 s faster. The biggest win is the configuration phase (36.0 s → 8.4 s), driven by the restored Gradle home. Cache overhead on the hit path is modest: ~13 s restore + 0.6 s store, a net saving of ~21 s per build.

No version bump or changelog entry: CI-only change, invisible to plugin consumers.
