### PR TITLE
Auto-merge GitHub Actions digest re-pins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,13 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
+    },
+    {
+      // Auto-merge GitHub Actions digest re-pins. Major version bumps are
+      // excluded by the update types and stay manual.
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "automerge": true,
     }
   ]
 }


### PR DESCRIPTION
GitHub Actions digest bumps land almost daily and just re-pin an action to a new SHA behind the same tag, so there's nothing to review. This auto-merges them once checks pass.

Major action version bumps are excluded and still need a manual merge.