### PR TITLE
Capture AI agent metadata at execution time

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,3 +1,1 @@
-- [FIX] Rename `AI Agent` tag to `AI`
-- [FIX] Rename `AI Agent` value key to `AI agent`
-- [NEW] For GitHub PRs, capture `GITHUB_BASE_REF` as the value `PR base branch`
+- [FIX] Changes to AI agent metadata invalidate the configuration cache

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -181,7 +181,7 @@ final class CustomBuildScanEnhancements {
             // Prepare project directory for use at execution time
             Provider<Directory> projectDirectory = providers.provider(() -> gradle.getRootProject().getLayout().getProjectDirectory());
 
-            // Process data at execution time not to have a CI environment variable (ie. build number) invalidates the configuration cache
+            // Process data at execution time so that CI metadata does not become a configuration cache input
             buildScan.buildFinished(new CaptureCiMetadataAction(develocity, providers, projectDirectory));
         }
     }
@@ -573,10 +573,12 @@ final class CustomBuildScanEnhancements {
 
     private void captureAgentMetadata() {
         Provider<String> androidStudioAgent = gradlePropertyProvider(PROJECT_PROP_ANDROID_STUDIO_AGENT, gradle, providers);
-        buildScan.background(new CaptureAgentMetadataAction(buildScan, providers, androidStudioAgent));
+
+        // Process data at execution time so that agent metadata does not become a configuration cache input
+        buildScan.buildFinished(new CaptureAgentMetadataAction(buildScan, providers, androidStudioAgent));
     }
 
-    private static final class CaptureAgentMetadataAction implements Action<BuildScanAdapter> {
+    private static final class CaptureAgentMetadataAction implements Action<BuildResultAdapter> {
 
         private final BuildScanAdapter buildScan;
         private final ProviderFactory providers;
@@ -589,7 +591,7 @@ final class CustomBuildScanEnhancements {
         }
 
         @Override
-        public void execute(BuildScanAdapter buildScan) {
+        public void execute(BuildResultAdapter buildResult) {
             Optional<String> claudeCode = envVariable("CLAUDECODE", providers);
             // Codex environment variables are not officially documented.
             // This is best effort detection until something more official is implemented by Codex.


### PR DESCRIPTION
Capturing AI agent metadata reads the `android.studio.agent` Gradle property and the AI agent environment variables through `buildScan.background`, which runs during configuration. That turns them into configuration cache inputs, so changing any of them discards the configuration cache even though they have no bearing on the task graph. The property is the one that bites in practice: it is set when Gemini in Android Studio invokes the build and absent otherwise, so alternating between agent and normal builds against the same checkout keeps invalidating the cache.

This moves the capture into a `buildScan.buildFinished` action, matching how IDE and CI metadata are already handled, so the values are read after configuration and never become inputs. The build scan tags and values are unchanged.

Fixes #499.

I verified the configuration cache behavior against a minimal settings build that applies Develocity and this plugin with the configuration cache enabled, resolving 2.6.0 from the Gradle Plugin Portal and 2.6.1 from a local build of this branch. The build runs three times in sequence with `android.studio.agent` omitted, then `true`, then `false`. With 2.6.0 every change to the property discards the cache; with 2.6.1 it is reused in all cases.

![Configuration cache reused with 2.6.1 but discarded with 2.6.0 across omitted, true, and false](https://raw.githubusercontent.com/gradle/common-custom-user-data-gradle-plugin/985ac3ceea1a4e2e7ca4bcff12bb43e7da069448/pr-assets/configuration-cache-comparison.png)

The configuration cache report from a 2.6.0 run names `android.studio.agent` as the input that forced the cache to be discarded, while reporting no problems:

![2.6.0 configuration cache report naming android.studio.agent](https://raw.githubusercontent.com/gradle/common-custom-user-data-gradle-plugin/985ac3ceea1a4e2e7ca4bcff12bb43e7da069448/pr-assets/configuration-cache-report-2.6.0.png)

I also confirmed that capturing at build-finished time produces the same scan content. Three build scans published from 2.6.1 against ge.solutions-team.gradle.com, one per state:

- Omitted: https://ge.solutions-team.gradle.com/s/oxevto44mypho, no `AI` tag and no `AI agent` value
- `-Pandroid.studio.agent=true`: https://ge.solutions-team.gradle.com/s/f4u52jehgp3wy, tagged `AI` with `AI agent` = `Gemini in Android Studio`
- `-Pandroid.studio.agent=false`: https://ge.solutions-team.gradle.com/s/5fb7zfyq3fqao, tagged `AI` with `AI agent` = `Gemini in Android Studio`

A build is treated as agent-invoked whenever the property is present, regardless of its value, so `false` is tagged the same as `true`. That is the existing behavior and is unchanged here.