### PR TITLE
Capture Cursor and detect Gemini in Android Studio via environment variables

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,3 @@
+- [NEW] Capture Cursor as an AI agent via the `CURSOR_AGENT` environment variable
+- [NEW] Capture Gemini in Android Studio as an AI agent via the `ANDROID_STUDIO_AGENT` environment variable
 - [FIX] Changes to AI agent metadata invalidate the configuration cache

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -597,6 +597,7 @@ final class CustomBuildScanEnhancements {
             // This is best effort detection until something more official is implemented by Codex.
             Optional<String> codexSandbox = envVariable("CODEX_SANDBOX_NETWORK_DISABLED", providers);
             Optional<String> codexThreadId = envVariable("CODEX_THREAD_ID", providers);
+            Optional<String> cursor = envVariable("CURSOR_AGENT", providers);
             Optional<String> openCode = envVariable("OPENCODE", providers);
             Optional<String> gemini = envVariable("GEMINI_CLI", providers);
 
@@ -608,6 +609,10 @@ final class CustomBuildScanEnhancements {
                 buildScan.tag("AI");
                 buildScan.value("AI agent", "Codex");
             }
+            cursor.ifPresent(env -> {
+                buildScan.tag("AI");
+                buildScan.value("AI agent", "Cursor");
+            });
             openCode.ifPresent(env -> {
                 buildScan.tag("AI");
                 buildScan.value("AI agent", "OpenCode");

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -600,6 +600,7 @@ final class CustomBuildScanEnhancements {
             Optional<String> cursor = envVariable("CURSOR_AGENT", providers);
             Optional<String> openCode = envVariable("OPENCODE", providers);
             Optional<String> gemini = envVariable("GEMINI_CLI", providers);
+            Optional<String> androidStudioAgentEnv = envVariable("ANDROID_STUDIO_AGENT", providers);
 
             claudeCode.ifPresent(env -> {
                 buildScan.tag("AI");
@@ -621,7 +622,7 @@ final class CustomBuildScanEnhancements {
                 buildScan.tag("AI");
                 buildScan.value("AI agent", "Gemini CLI");
             });
-            if (androidStudioAgent.isPresent()) {
+            if (androidStudioAgent.isPresent() || androidStudioAgentEnv.isPresent()) {
                 buildScan.tag("AI");
                 buildScan.value("AI agent", "Gemini in Android Studio");
             }


### PR DESCRIPTION
This adds Cursor to the AI agents captured on the build scan, detected via the `CURSOR_AGENT` environment variable that Cursor's CLI sets when it runs shell commands.

It also detects Gemini in Android Studio via the `ANDROID_STUDIO_AGENT` environment variable in addition to the existing `android.studio.agent` Gradle property. Either one present tags the build, so detection keeps working whether Android Studio exposes the agent through the property, the environment, or both. Versions that only set the property are still detected.

This comes out of the discussion on #513. Thanks to @ganadist for that PR and for the original agent detection in #465, both of which prompted these changes. We're going to be more selective about which AI tools we detect going forward, and we'd rather keep the structure of the existing file than move to the map approach, so I recreated just the pieces we wanted directly.

The commit messages document the source for each variable. `CURSOR_AGENT` is confirmed by Cursor staff and used by several cross-vendor detectors. `ANDROID_STUDIO_AGENT` is not officially documented but is detected by Google's own tooling.
