### PR TITLE
Link Develocity Gradle plugin API reference instead of pinned Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This approach has a number of benefits:
 If your customized plugin provides all required Develocity configuration, then a consumer project will get all the benefits of Develocity simply by applying the plugin. The
 project sources provide a good template to get started with your own plugin.
 
-Refer to the [Javadoc](https://docs.develocity.ai/downloads/gradle-plugin-javadoc/4.5.0/) for more details on the key types available for use.
+Refer to the [API reference](https://docs.develocity.ai/gradle/current/gradle-plugin/#api-reference) for more details on the key types available for use.
 
 See the [Gradle User Manual](https://docs.gradle.org/current/userguide/publishing_binary_plugin_advanced.html) for more details on publishing Gradle plugins to an internal repository.
 


### PR DESCRIPTION
Follow-up to #528. That PR updated the Develocity Gradle plugin Javadoc link in `README.md` to the version-pinned `https://docs.develocity.ai/downloads/gradle-plugin-javadoc/4.5.0/`.

Rather than pinning a version and automating the bump, this points at the version-less **API reference** section of the Develocity Gradle plugin user manual:

```
https://docs.develocity.ai/gradle/current/gradle-plugin/#api-reference
```

- `current` is a stable alias that redirects to the latest published version (today 4.5), preserving the URL fragment, so the link never goes stale.
- That section is the canonical entry point to the API docs for the key types the CCUD plugin builds on.
- The link text changes from "Javadoc" to "API reference" to match the destination.

Because the URL is no longer version-pinned, **no Renovate automation is needed** — the `customManager` originally proposed in this PR has been dropped, and `.github/renovate.json5` is untouched.

Same approach applied to the sbt plugin in gradle/common-custom-user-data-sbt-plugin#127.

> Note: the branch name (`chore/renovate-track-gradle-plugin-javadoc`) is a leftover from the original Renovate-based approach and no longer describes the change.
