### PR TITLE
Detect GitHub Copilot CLI as an AI agent

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- [NEW] TBD
+- [NEW] Detect GitHub Copilot CLI via the `COPILOT_CLI` environment variable, capturing the `AI` tag and `AI agent` value `Copilot CLI`

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -600,6 +600,7 @@ final class CustomBuildScanEnhancements {
             Optional<String> cursor = envVariable("CURSOR_AGENT", providers);
             Optional<String> openCode = envVariable("OPENCODE", providers);
             Optional<String> gemini = envVariable("GEMINI_CLI", providers);
+            Optional<String> copilot = envVariable("COPILOT_CLI", providers);
             Optional<String> androidStudioAgentEnv = envVariable("ANDROID_STUDIO_AGENT", providers);
 
             claudeCode.ifPresent(env -> {
@@ -621,6 +622,10 @@ final class CustomBuildScanEnhancements {
             gemini.ifPresent(env -> {
                 buildScan.tag("AI");
                 buildScan.value("AI agent", "Gemini CLI");
+            });
+            copilot.ifPresent(env -> {
+                buildScan.tag("AI");
+                buildScan.value("AI agent", "Copilot CLI");
             });
             if (androidStudioAgent.isPresent() || androidStudioAgentEnv.isPresent()) {
                 buildScan.tag("AI");


### PR DESCRIPTION
Capture the `AI` tag and `AI agent` value `Copilot CLI` when the `COPILOT_CLI` environment variable is present, matching the existing detection for Claude Code, Codex, Cursor, OpenCode, and Gemini CLI.