### PR TITLE
Remove the image-names cache-isolation rationale comment

### DIFF
--- a/.github/workflows/build-verification-nightly.yml
+++ b/.github/workflows/build-verification-nightly.yml
@@ -69,9 +69,6 @@ jobs:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
-      # These legs differ only by gradle-version, which the auto-generated cache
-      # name does not isolate, so a shared cache image would thrash on save
-      # (last writer wins). image-names gives each gradle-version its own image.
       - name: Setup Develocity Artifact Cache
         uses: gradle/develocity-artifact-cache-github-action@v0.0.5-rc-3
         with:

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -82,12 +82,6 @@ jobs:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
-      # These legs differ by gradle-version, which the auto-generated cache name
-      # does not isolate (it hashes workflow/job/ref/os/arch, and GITHUB_JOB is
-      # the same for every matrix leg). Different Gradle versions resolve
-      # different artifact sets, so a shared cache image would thrash on save
-      # (last writer wins). image-names gives each gradle-version its own
-      # cache image.
       - name: Setup Develocity Artifact Cache
         if: matrix.universal-cache
         uses: gradle/develocity-artifact-cache-github-action@v0.0.5-rc-3


### PR DESCRIPTION
## Summary

In response to https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/538#discussion_r3825093178

Removes the multi-line comment above the **Setup Develocity Artifact Cache** step in both `build-verification.yml` and `build-verification-nightly.yml` that explained why each Gradle-version matrix leg needs its own `image-names` (to avoid a shared cache image thrashing on save). The `image-names: ccud-gradle[-nightly]-${{ matrix.gradle-version }}` value is self-explanatory, so the rationale block is dropped.

No behavior change — comment-only removal; the `image-names` inputs and every other step are untouched.

## Files
- `.github/workflows/build-verification.yml` — drop 6-line comment
- `.github/workflows/build-verification-nightly.yml` — drop 3-line comment