### PR TITLE
Bump Develocity Artifact Cache GitHub Action to v1

### DIFF
--- a/.github/workflows/build-verification-nightly.yml
+++ b/.github/workflows/build-verification-nightly.yml
@@ -31,7 +31,7 @@ jobs:
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: 'release-candidate'
       - name: Setup Develocity Artifact Cache
-        uses: gradle/develocity-artifact-cache-github-action@484d1b6daf36415410336eed9d8c3579f0fb55fd # v0.0.5
+        uses: gradle/develocity-artifact-cache-github-action@v1
         with:
           develocity-url: https://ge.solutions-team.gradle.com
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
@@ -70,7 +70,7 @@ jobs:
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
           gradle-version: '${{ matrix.gradle-version }}'
       - name: Setup Develocity Artifact Cache
-        uses: gradle/develocity-artifact-cache-github-action@484d1b6daf36415410336eed9d8c3579f0fb55fd # v0.0.5
+        uses: gradle/develocity-artifact-cache-github-action@v1
         with:
           develocity-url: https://ge.solutions-team.gradle.com
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}

--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -25,7 +25,7 @@ jobs:
           cache-disabled: true
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Setup Develocity Artifact Cache
-        uses: gradle/develocity-artifact-cache-github-action@484d1b6daf36415410336eed9d8c3579f0fb55fd # v0.0.5
+        uses: gradle/develocity-artifact-cache-github-action@v1
         with:
           develocity-url: https://ge.solutions-team.gradle.com
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
@@ -84,7 +84,7 @@ jobs:
           gradle-version: '${{ matrix.gradle-version }}'
       - name: Setup Develocity Artifact Cache
         if: matrix.universal-cache
-        uses: gradle/develocity-artifact-cache-github-action@484d1b6daf36415410336eed9d8c3579f0fb55fd # v0.0.5
+        uses: gradle/develocity-artifact-cache-github-action@v1
         with:
           develocity-url: https://ge.solutions-team.gradle.com
           develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

Points the `build-verification` and `build-verification-nightly` workflows at the Develocity Artifact Cache GitHub Action **`@v1`** (GA), consuming the moving major-version tag so the workflows pick up v1.x patches automatically.

Supersedes the earlier release-candidate reference on this branch (`v0.0.5-rc-4`); `v1` / `v1.0.0` were cut from that same commit.

## Changes
- `.github/workflows/build-verification.yml` — 2 refs → `@v1`
- `.github/workflows/build-verification-nightly.yml` — 2 refs → `@v1`
